### PR TITLE
Feature/#10 로그인/회원가입 외 endpoint AccessDenied 문제 해결

### DIFF
--- a/src/main/java/com/duktown/domain/user/service/UserService.java
+++ b/src/main/java/com/duktown/domain/user/service/UserService.java
@@ -68,8 +68,8 @@ public class UserService {
         User user = signupRequest.toEntity(encodedPassword);
         userRepository.save(user);
 
-        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getId(), user.getRoleType());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail(), user.getId(), user.getRoleType());
+        String accessToken = jwtTokenProvider.createAccessToken(user.getLoginId(), user.getId(), user.getRoleType());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getLoginId(), user.getId(), user.getRoleType());
         user.updateRefreshToken(refreshToken);
         return new UserDto.SignUpResponse(accessToken, refreshToken);
     }

--- a/src/main/java/com/duktown/global/security/SecurityConfig.java
+++ b/src/main/java/com/duktown/global/security/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.duktown.global.security;
 
-import com.duktown.global.security.filter.CustomAuthenticationFilter;
+import com.duktown.global.security.filter.JwtAuthenticationFilter;
 import com.duktown.global.security.filter.JwtAuthorizationFilter;
 import com.duktown.global.security.handler.JwtAccessDeniedHandler;
 import com.duktown.global.security.handler.JwtAuthenticationEntryPoint;
@@ -47,8 +47,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        CustomAuthenticationFilter authenticationFilter =
-                new CustomAuthenticationFilter(authenticationManagerBuilder.getOrBuild());
+        JwtAuthenticationFilter authenticationFilter =
+                new JwtAuthenticationFilter(authenticationManagerBuilder.getOrBuild());
 
         authenticationFilter.setFilterProcessesUrl("/auth/login");
         authenticationFilter.setAuthenticationSuccessHandler(authenticationSuccessHandler);

--- a/src/main/java/com/duktown/global/security/SecurityConfig.java
+++ b/src/main/java/com/duktown/global/security/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.duktown.global.security;
 
 import com.duktown.global.security.filter.CustomAuthenticationFilter;
-import com.duktown.global.security.filter.JwtAuthenticationFilter;
+import com.duktown.global.security.filter.JwtAuthorizationFilter;
 import com.duktown.global.security.handler.JwtAccessDeniedHandler;
 import com.duktown.global.security.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.*;
 public class SecurityConfig {
 
     private final AuthenticationProvider authenticationProvider;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final AuthenticationSuccessHandler authenticationSuccessHandler;
     private final AuthenticationFailureHandler authenticationFailureHandler;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(STATELESS)   // 세션 사용 x
                 .and()
                 .addFilter(authenticationFilter)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authenticationProvider(authenticationProvider)
                 .authorizeHttpRequests((auth) -> {
                     Arrays.stream(AUTH_WHITE_LIST)

--- a/src/main/java/com/duktown/global/security/dto/LoginRequestDto.java
+++ b/src/main/java/com/duktown/global/security/dto/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package com.duktown.global.security.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class LoginRequestDto {
+    @NotBlank(message = "아이디는 필수 값입니다.")
+    private String loginId;
+    @NotBlank(message = "비밀번호는 필수 값입니다.")
+    private String password;
+}

--- a/src/main/java/com/duktown/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/duktown/global/security/filter/JwtAuthenticationFilter.java
@@ -9,13 +9,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotEmpty;
 
 // 인증 필터 : HTTP Request를 낚아챔
 // 요청의 username과 password를 이용해 토큰 생성
 // 토큰을 AuthenticationManager가 받아 AuthenticationProvider에게 넘겨준다
 @RequiredArgsConstructor
-public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
 

--- a/src/main/java/com/duktown/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/duktown/global/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.duktown.global.security.filter;
 
+import com.duktown.global.exception.CustomException;
+import com.duktown.global.security.dto.LoginRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -9,6 +12,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static com.duktown.global.exception.CustomErrorType.SERVER_INTERNAL_ERROR;
 
 // 인증 필터 : HTTP Request를 낚아챔
 // 요청의 username과 password를 이용해 토큰 생성
@@ -20,11 +25,18 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws AuthenticationException {
-        // TODO: 아이디, 비밀번호 입력 x 시 실패 처리
-        String loginId = httpServletRequest.getParameter("loginId");
-        String password = httpServletRequest.getParameter("password");
+        ObjectMapper objectMapper = new ObjectMapper();
+        LoginRequestDto loginRequestDto;
+        try {
+            loginRequestDto = objectMapper.readValue(httpServletRequest.getInputStream(), LoginRequestDto.class);
+        } catch (Exception e) {
+            throw new CustomException(SERVER_INTERNAL_ERROR);   // TODO: CustomException ErrorResponse 처리
+        }
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(loginId, password);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                loginRequestDto.getLoginId(),
+                loginRequestDto.getPassword()
+        );
 
         return authenticationManager.authenticate(authentication);
     }

--- a/src/main/java/com/duktown/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/duktown/global/security/filter/JwtAuthorizationFilter.java
@@ -23,7 +23,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/duktown/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/duktown/global/security/filter/JwtAuthorizationFilter.java
@@ -32,8 +32,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String accessToken = jwtTokenProvider.getToken(request);
 
         if (accessToken != null) {
+            jwtTokenProvider.validateToken(accessToken);
             try {
-                jwtTokenProvider.validateToken(accessToken);
                 Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/com/duktown/global/security/handler/UserAuthenticationFailureHandler.java
+++ b/src/main/java/com/duktown/global/security/handler/UserAuthenticationFailureHandler.java
@@ -6,7 +6,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -15,15 +14,11 @@ import static com.duktown.global.exception.CustomErrorType.LOGIN_FAILED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Component
-public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+public class UserAuthenticationFailureHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
         response.setContentType(APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
-
-        // 특정 인증 예외에 대해 처리하고 싶다면 아래 코드 활용
-        // Class<? extends AuthenticationException> exceptionClass = exception.getClass();
-
         response.setStatus(LOGIN_FAILED.getStatusCode());
         new ObjectMapper().writeValue(response.getWriter(), new ErrorResponse(LOGIN_FAILED));
     }

--- a/src/main/java/com/duktown/global/security/handler/UserAuthenticationSuccessHandler.java
+++ b/src/main/java/com/duktown/global/security/handler/UserAuthenticationSuccessHandler.java
@@ -13,7 +13,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -22,10 +21,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Component
 @RequiredArgsConstructor
-public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+public class UserAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     @Override
@@ -36,8 +35,8 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
                 .orElseThrow(() -> new UsernameNotFoundException("가입된 아이디가 존재하지 않습니다."));
 
         // JWT Token 생성, 응답
-        String accessToken = jwtService.createAccessToken(user.getLoginId(), user.getId(), user.getRoleType());
-        String refreshToken = jwtService.createRefreshToken(user.getLoginId(), user.getId(), user.getRoleType());
+        String accessToken = jwtTokenProvider.createAccessToken(user.getLoginId(), user.getId(), user.getRoleType());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getLoginId(), user.getId(), user.getRoleType());
 
         user.updateRefreshToken(refreshToken);
         response.setContentType(APPLICATION_JSON_VALUE);

--- a/src/main/java/com/duktown/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/duktown/global/security/provider/JwtTokenProvider.java
@@ -122,12 +122,12 @@ public class JwtTokenProvider {
 
     // Token에서 사용자 ID 추출 메서드
     public Long getUserId(String token) {
-        return (Long) getClaim(token).get(CLAIM_ID);
+        return getClaim(token).get(CLAIM_ID, Long.class);
     }
 
     // Token에서 사용자 RoleType 추출 메서드
     public RoleType getRoleType(String token) {
-        return (RoleType) getClaim(token).get(CLAIM_ROLE);
+        return getClaim(token).get(CLAIM_ROLE, RoleType.class);
     }
 
     // Token 유효성 검증 메서드

--- a/src/main/java/com/duktown/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/duktown/global/security/provider/JwtTokenProvider.java
@@ -7,6 +7,7 @@ import com.duktown.global.security.service.CustomUserDetails;
 import com.duktown.global.type.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -84,7 +85,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
                 .setSubject(loginId)
-                .setIssuedAt(new Date())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXP_TIME))
                 .claim(CLAIM_ID, userId)
                 .claim(CLAIM_ROLE, roleType.getKey())
@@ -97,7 +98,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setHeaderParam("typ", "JWT")
                 .setSubject(loginId)
-                .setIssuedAt(new Date())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXP_TIME))
                 .claim(CLAIM_ID, userId)
                 .claim(CLAIM_ROLE, roleType.getKey())
@@ -141,7 +142,7 @@ public class JwtTokenProvider {
                     .setSigningKey(jwtSecretKey)
                     .build()
                     .parseClaimsJws(token);
-        } catch (IllegalArgumentException | UnsupportedJwtException | MalformedJwtException e) {
+        } catch (SignatureException | IllegalArgumentException | UnsupportedJwtException | MalformedJwtException e) {
             throw new CustomException(INVALID_TOKEN);
         } catch (ExpiredJwtException e) {
             throw new CustomException(ACCESS_TOKEN_EXPIRED);

--- a/src/main/java/com/duktown/global/security/provider/UserAuthenticationProvider.java
+++ b/src/main/java/com/duktown/global/security/provider/UserAuthenticationProvider.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 // UserDetails 객체 반환
 @Component
 @RequiredArgsConstructor
-public class CustomAuthenticationProvider implements AuthenticationProvider {
+public class UserAuthenticationProvider implements AuthenticationProvider {
 
     private final UserDetailsService userDetailsService;
     private final PasswordEncoder passwordEncoder;
@@ -29,8 +29,8 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
         CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(loginId);
 
-        if (userDetails == null || !passwordEncoder.matches(password, userDetails.getPassword())) {
-            throw new BadCredentialsException("아이디 또는 비밀번호가 일치하지 않습니다.");
+        if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/duktown/global/security/service/CustomUserDetails.java
+++ b/src/main/java/com/duktown/global/security/service/CustomUserDetails.java
@@ -58,4 +58,8 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;   // 사용 가능
     }
+
+    public Long getId() {
+        return user.getId();
+    }
 }

--- a/src/test/java/com/duktown/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/com/duktown/unit/user/controller/UserControllerTest.java
@@ -4,7 +4,7 @@ import com.duktown.domain.user.controller.UserController;
 import com.duktown.domain.user.dto.UserDto;
 import com.duktown.domain.user.service.UserService;
 import com.duktown.global.security.SecurityConfig;
-import com.duktown.global.security.filter.JwtAuthenticationFilter;
+import com.duktown.global.security.filter.JwtAuthorizationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
                 type = FilterType.ASSIGNABLE_TYPE,
                 classes = {
                         SecurityConfig.class,
-                        JwtAuthenticationFilter.class
+                        JwtAuthorizationFilter.class
                 }
         )
 )


### PR DESCRIPTION
## 📝 PR 내용
로그인/회원가입을 제외한 모든 인증이 필요한 endPoint에 대해 AccessDenied 오류가 발생하는 문제를 해결했습니다.

이는 JWT 토큰으로부터 유저 정보를 제대로 얻어오지 못하고 있기 때문인데, userService에서 토큰 발급 메소드에 잘못된 파라미터를 입력하는 것과, jwtTokenProvider 코드에서 parserBuilder 관련 메소드의 잘못된 사용이 원인이었습니다. 이를 수정했습니다.

또한 인증이 필요한 endPoint에 대해 Controller에서 JWT 토큰으로부터 유저 정보를 획득할 수 있도록 userDetails 구현 클래스를 변경했고, 추가적으로 login 시 필요한 아이디, 비밀번호를 파라미터로 받지 않고 DTO를 통해 받을 수 있도록 변경했습니다.

## 관련 이슈
close #10 
