### PR TITLE
Feature/#17 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/duktown/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/duktown/domain/comment/dto/CommentDto.java
@@ -3,6 +3,7 @@ package com.duktown.domain.comment.dto;
 import com.duktown.domain.comment.entity.Comment;
 import com.duktown.domain.daily.entity.Daily;
 import com.duktown.domain.delivery.entity.Delivery;
+import com.duktown.domain.like.entity.Like;
 import com.duktown.domain.market.entity.Market;
 import com.duktown.domain.user.entity.User;
 import com.duktown.global.util.DateUtil;
@@ -48,9 +49,9 @@ public class CommentDto {
         private Long commentCount;
         private List<ParentResponse> content;
 
-        public static ListResponse from(Long commentCount, List<Comment> comments){
+        public static ListResponse from(Long commentCount, List<Comment> comments, List<Like> likes){
             List<ParentResponse> content = comments.stream()
-                    .map(ParentResponse::from)
+                    .map(c -> ParentResponse.from(c, likes))
                     .collect(Collectors.toList());
             return ListResponse.builder()
                     .commentCount(commentCount)
@@ -66,18 +67,22 @@ public class CommentDto {
         private Long commentId;
         private Long userId;
         private String content;
+        private Boolean liked;
+        private Integer likeCount;
         private String dateTime;
         private Boolean deleted;
         private List<ChildResponse> childComments;
 
-        public static ParentResponse from(Comment comment) {
+        public static ParentResponse from(Comment comment, List<Like> likes) {
             List<ChildResponse> childComments = comment.getChildComments().stream()
-                    .map(ChildResponse::from)
+                    .map(c -> ChildResponse.from(c, likes))
                     .collect(Collectors.toList());
             return ParentResponse.builder()
                     .commentId(comment.getId())
                     .userId(comment.getUser().getId())
                     .content(comment.getContent())
+                    .liked(likes.stream().anyMatch(l -> l.getComment().getId().equals(comment.getId())))
+                    .likeCount(comment.getLikes().size())
                     .dateTime(DateUtil.convert(comment.getCreatedAt()))
                     .deleted(comment.getDeleted())
                     .childComments(childComments)
@@ -92,13 +97,17 @@ public class CommentDto {
         private Long commentId;
         private Long userId;
         private String content;
+        private Boolean liked;
+        private Integer likeCount;
         private String dateTime;
 
-        public static ChildResponse from(Comment comment) {
+        public static ChildResponse from(Comment comment, List<Like> likes) {
             return ChildResponse.builder()
                     .commentId(comment.getId())
                     .userId(comment.getUser().getId())
                     .content(comment.getContent())
+                    .liked(likes.stream().anyMatch(l -> l.getComment().getId().equals(comment.getId())))
+                    .likeCount(comment.getLikes().size())
                     .dateTime(DateUtil.convert(comment.getCreatedAt()))
                     .build();
         }

--- a/src/main/java/com/duktown/domain/comment/entity/Comment.java
+++ b/src/main/java/com/duktown/domain/comment/entity/Comment.java
@@ -3,6 +3,7 @@ package com.duktown.domain.comment.entity;
 import com.duktown.domain.BaseTimeEntity;
 import com.duktown.domain.daily.entity.Daily;
 import com.duktown.domain.delivery.entity.Delivery;
+import com.duktown.domain.like.entity.Like;
 import com.duktown.domain.market.entity.Market;
 import com.duktown.domain.user.entity.User;
 import lombok.AllArgsConstructor;
@@ -55,6 +56,9 @@ public class Comment extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String content; // 255자 최대
+
+    @OneToMany(mappedBy = "comment")
+    private List<Like> likes = new ArrayList<>();
 
     @Column(nullable = false)
     private Boolean deleted;

--- a/src/main/java/com/duktown/domain/comment/entity/CommentRepository.java
+++ b/src/main/java/com/duktown/domain/comment/entity/CommentRepository.java
@@ -10,13 +10,17 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query(value = "select c from Comment as c where c.parentComment.id is null and c.delivery.id = :delivery_id")
-    List<Comment> findAllByDeliveryId(@Param("delivery_id") Long deliveryId);
+    List<Comment> findParentCommentsByDeliveryId(@Param("delivery_id") Long deliveryId);
 
     @Query(value = "select c from Comment as c where c.parentComment.id is null and c.daily.id = :daily_id")
-    List<Comment> findAllByDailyId(@Param("daily_id") Long dailyId);
+    List<Comment> findParentCommentsByDailyId(@Param("daily_id") Long dailyId);
 
     @Query(value = "select c from Comment as c where c.parentComment.id is null and c.market.id = :market_id")
-    List<Comment> findAllByMarketId(@Param("market_id") Long marketId);
+    List<Comment> findParentCommentsByMarketId(@Param("market_id") Long marketId);
+
+    List<Comment> findAllByDeliveryId(Long deliveryId);
+    List<Comment> findAllByDailyId(Long dailyId);
+    List<Comment> findAllByMarketId(Long marketId);
 
     Boolean existsByParentCommentId(Long parentCommentId);
 

--- a/src/main/java/com/duktown/domain/comment/service/CommentService.java
+++ b/src/main/java/com/duktown/domain/comment/service/CommentService.java
@@ -136,6 +136,9 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
 
+        // 좋아요 삭제
+        likeRepository.deleteByCommentId(commentId);
+
         // 본인 댓글인지 확인
         if (!comment.getUser().getId().equals(user.getId())) {
             throw new CustomException(HAVE_NO_PERMISSION);

--- a/src/main/java/com/duktown/domain/comment/service/CommentService.java
+++ b/src/main/java/com/duktown/domain/comment/service/CommentService.java
@@ -19,7 +19,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.duktown.global.exception.CustomErrorType.*;
 
@@ -35,6 +37,16 @@ public class CommentService {
     private final LikeRepository likeRepository;
 
     public void createComment(Long userId, CommentDto.CreateRequest request){
+        // null이 아닌 필드가 여러 개일 때(대댓글 경우 제외) -> 잘못된 댓글 요청
+        if (Stream.of(
+                        request.getDeliveryId(),
+                        request.getDailyId(),
+                        request.getMarketId())
+                .filter(Objects::nonNull)
+                .count() >= 2) {
+            throw new CustomException(COMMENT_TARGET_ERROR);
+        }
+
         // 사용자
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -73,6 +85,16 @@ public class CommentService {
     // TODO: queryDsl 도입해 대댓글 조회 기능 수정
     @Transactional(readOnly = true)
     public CommentDto.ListResponse getCommentList(Long userId, Long deliveryId, Long dailyId, Long marketId){
+        // null이 아닌 필드가 여러 개일 때(대댓글 경우 제외) -> 잘못된 댓글 요청
+        if (Stream.of(
+                        deliveryId,
+                        dailyId,
+                        marketId)
+                .filter(Objects::nonNull)
+                .count() >= 2) {
+            throw new CustomException(COMMENT_TARGET_ERROR);
+        }
+
         List<Comment> comments;
         Long commentCount;
         List<Like> likes;

--- a/src/main/java/com/duktown/domain/comment/service/CommentService.java
+++ b/src/main/java/com/duktown/domain/comment/service/CommentService.java
@@ -67,6 +67,7 @@ public class CommentService {
     }
 
     // TODO: queryDsl 도입해 대댓글 조회 기능 수정
+    // TODO: 현재 로그인한 사용자가 좋아요한 댓글 표시
     @Transactional(readOnly = true)
     public CommentDto.ListResponse getCommentList(Long userId, Long deliveryId, Long dailyId, Long marketId){
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));

--- a/src/main/java/com/duktown/domain/comment/service/CommentService.java
+++ b/src/main/java/com/duktown/domain/comment/service/CommentService.java
@@ -73,8 +73,6 @@ public class CommentService {
     // TODO: queryDsl 도입해 대댓글 조회 기능 수정
     @Transactional(readOnly = true)
     public CommentDto.ListResponse getCommentList(Long userId, Long deliveryId, Long dailyId, Long marketId){
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
         List<Comment> comments;
         Long commentCount;
         List<Like> likes;

--- a/src/main/java/com/duktown/domain/comment/service/CommentService.java
+++ b/src/main/java/com/duktown/domain/comment/service/CommentService.java
@@ -41,7 +41,6 @@ public class CommentService {
             parentComment = commentRepository.findById(request.getParentCommentId())
                     .orElseThrow(() -> new CustomException(PARENT_COMMENT_NOT_FOUND));
 
-            // TODO: 이부분 지우고 나중에 따로 commit
             if(parentComment.getParentComment() != null){
                 throw new CustomException(COMMENT_DEPTH_ERROR);
             }

--- a/src/main/java/com/duktown/domain/like/controller/LikeController.java
+++ b/src/main/java/com/duktown/domain/like/controller/LikeController.java
@@ -1,0 +1,31 @@
+package com.duktown.domain.like.controller;
+
+import com.duktown.domain.like.service.LikeService;
+import com.duktown.global.security.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/likes")
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping
+    public ResponseEntity<Void> createLike(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "deliveryId", required = false) Long deliveryId,
+            @RequestParam(value = "dailyId", required = false) Long dailyId,
+            @RequestParam(value = "marketId", required = false) Long marketId,
+            @RequestParam(value = "commentId", required = false) Long commentId
+    ) {
+        likeService.createLike(customUserDetails.getId(), deliveryId, dailyId, marketId, commentId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/duktown/domain/like/controller/LikeController.java
+++ b/src/main/java/com/duktown/domain/like/controller/LikeController.java
@@ -1,14 +1,12 @@
 package com.duktown.domain.like.controller;
 
+import com.duktown.domain.like.dto.LikeDto;
 import com.duktown.domain.like.service.LikeService;
 import com.duktown.global.security.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,15 +15,14 @@ public class LikeController {
 
     private final LikeService likeService;
 
+    // 좋아요 추가, 취소
     @PostMapping
-    public ResponseEntity<Void> createLike(
+    public ResponseEntity<LikeDto.LikeResponse> like(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestParam(value = "deliveryId", required = false) Long deliveryId,
-            @RequestParam(value = "dailyId", required = false) Long dailyId,
-            @RequestParam(value = "marketId", required = false) Long marketId,
-            @RequestParam(value = "commentId", required = false) Long commentId
+            @RequestBody LikeDto.LikeRequest request
     ) {
-        likeService.createLike(customUserDetails.getId(), deliveryId, dailyId, marketId, commentId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(
+                likeService.like(customUserDetails.getId(), request)
+        );
     }
 }

--- a/src/main/java/com/duktown/domain/like/dto/LikeDto.java
+++ b/src/main/java/com/duktown/domain/like/dto/LikeDto.java
@@ -1,0 +1,33 @@
+package com.duktown.domain.like.dto;
+
+import com.duktown.domain.comment.entity.Comment;
+import com.duktown.domain.daily.entity.Daily;
+import com.duktown.domain.delivery.entity.Delivery;
+import com.duktown.domain.like.entity.Like;
+import com.duktown.domain.market.entity.Market;
+import com.duktown.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class LikeDto {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class LikeRequest {
+        private Long deliveryId;
+        private Long dailyId;
+        private Long marketId;
+        private Long commentId;
+
+        public static Like toEntity(User user, Delivery delivery, Daily daily, Market market, Comment comment) {
+            return Like.builder()
+                    .delivery(delivery)
+                    .daily(daily)
+                    .market(market)
+                    .comment(comment)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/duktown/domain/like/dto/LikeDto.java
+++ b/src/main/java/com/duktown/domain/like/dto/LikeDto.java
@@ -23,11 +23,19 @@ public class LikeDto {
 
         public static Like toEntity(User user, Delivery delivery, Daily daily, Market market, Comment comment) {
             return Like.builder()
+                    .user(user)
                     .delivery(delivery)
                     .daily(daily)
                     .market(market)
                     .comment(comment)
                     .build();
         }
+    }
+
+    // TODO: 게시글 관련 타 dto에 likeCount와 liked 필드 추가하기
+    @AllArgsConstructor
+    @Getter
+    public static class LikeResponse {
+        private Boolean liked;
     }
 }

--- a/src/main/java/com/duktown/domain/like/entity/Like.java
+++ b/src/main/java/com/duktown/domain/like/entity/Like.java
@@ -1,5 +1,7 @@
 package com.duktown.domain.like.entity;
 
+import com.duktown.domain.BaseTimeEntity;
+import com.duktown.domain.comment.entity.Comment;
 import com.duktown.domain.daily.entity.Daily;
 import com.duktown.domain.delivery.entity.Delivery;
 import com.duktown.domain.market.entity.Market;
@@ -21,7 +23,7 @@ import static lombok.AccessLevel.PROTECTED;
 @AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "likes")
-public class Like {
+public class Like extends BaseTimeEntity {
     @Id
     @GeneratedValue
     @Column(name = "like_id")
@@ -32,14 +34,18 @@ public class Like {
     private User user;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "delivery_id", nullable = false)
+    @JoinColumn(name = "delivery_id")
     private Delivery delivery;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "daily_id", nullable = false)
+    @JoinColumn(name = "daily_id")
     private Daily daily;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "market_id", nullable = false)
+    @JoinColumn(name = "market_id")
     private Market market;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
 }

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -1,6 +1,7 @@
 package com.duktown.domain.like.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -24,5 +25,7 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             "and l.comment.id in :commentIds")
     List<Like> findAllByUserAndCommentIn(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
 
-    void deleteByCommentId(Long commentId);
+    @Modifying
+    @Query("delete from Like l where l.comment.id = :commentId")
+    void deleteByCommentId(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -1,0 +1,9 @@
+package com.duktown.domain.like.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+}

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -5,18 +5,24 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    @Query(value = "select l from Like as l where l.user.id = :user_id and l.delivery.id = :delivery_id")
-    Like findByUserIdAndDeliveryId(@Param("user_id") Long userId, @Param("delivery_id") Long deliveryId);
+    Like findByUserIdAndDeliveryId(Long userId, Long deliveryId);
 
-    @Query(value = "select l from Like as l where l.user.id = :user_id and l.daily.id = :daily_id")
-    Like findByUserIdAndDailyId(@Param("user_id") Long userId, @Param("daily_id") Long dailyId);
+    Like findByUserIdAndDailyId(Long userId, Long dailyId);
 
-    @Query(value = "select l from Like as l where l.user.id = :user_id and l.daily.id = :market_id")
-    Like findByUserIdAndMarketId(@Param("user_id") Long userId, @Param("market_id") Long marketId);
+    Like findByUserIdAndMarketId(Long userId, Long marketId);
 
-    @Query(value = "select l from Like as l where l.user.id = :user_id and l.comment.id = :comment_id")
-    Like findByUserIdAndCommentId(@Param("user_id") Long userId, @Param("comment_id") Long commentId);
+    Like findByUserIdAndCommentId(Long userId, Long commentId);
+
+    @Query("select l from Like l " +
+            "join fetch l.comment c " +
+            "where l.user.id = :userId " +
+            "and l.comment.id in :commentIds")
+    List<Like> findAllByUserAndCommentIn(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
+
+
 }

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -1,9 +1,22 @@
 package com.duktown.domain.like.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
+    @Query(value = "select l from Like as l where l.user.id = :user_id and l.delivery.id = :delivery_id")
+    Like findByUserIdAndDeliveryId(@Param("user_id") Long userId, @Param("delivery_id") Long deliveryId);
+
+    @Query(value = "select l from Like as l where l.user.id = :user_id and l.daily.id = :daily_id")
+    Like findByUserIdAndDailyId(@Param("user_id") Long userId, @Param("daily_id") Long dailyId);
+
+    @Query(value = "select l from Like as l where l.user.id = :user_id and l.daily.id = :market_id")
+    Like findByUserIdAndMarketId(@Param("user_id") Long userId, @Param("market_id") Long marketId);
+
+    @Query(value = "select l from Like as l where l.user.id = :user_id and l.comment.id = :comment_id")
+    Like findByUserIdAndCommentId(@Param("user_id") Long userId, @Param("comment_id") Long commentId);
 }

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -24,5 +24,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             "and l.comment.id in :commentIds")
     List<Like> findAllByUserAndCommentIn(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
 
-
+    void deleteByCommentId(Long commentId);
 }

--- a/src/main/java/com/duktown/domain/like/service/LikeService.java
+++ b/src/main/java/com/duktown/domain/like/service/LikeService.java
@@ -1,0 +1,66 @@
+package com.duktown.domain.like.service;
+
+import com.duktown.domain.comment.entity.Comment;
+import com.duktown.domain.comment.entity.CommentRepository;
+import com.duktown.domain.daily.entity.Daily;
+import com.duktown.domain.daily.entity.DailyRepository;
+import com.duktown.domain.delivery.entity.Delivery;
+import com.duktown.domain.delivery.entity.DeliveryRepository;
+import com.duktown.domain.like.dto.LikeDto;
+import com.duktown.domain.like.entity.Like;
+import com.duktown.domain.like.entity.LikeRepository;
+import com.duktown.domain.market.entity.Market;
+import com.duktown.domain.market.entity.MarketRepository;
+import com.duktown.domain.user.entity.User;
+import com.duktown.domain.user.entity.UserRepository;
+import com.duktown.global.exception.CustomErrorType;
+import com.duktown.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.duktown.global.exception.CustomErrorType.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final DeliveryRepository deliveryRepository;
+    private final DailyRepository dailyRepository;
+    private final MarketRepository marketRepository;
+    private final CommentRepository commentRepository;
+
+    // 좋아요 추가
+    public void createLike(Long userId, Long deliveryId, Long dailyId, Long marketId, Long commentId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Delivery delivery = null;
+        Daily daily = null;
+        Market market = null;
+        Comment comment = null;
+
+        if (deliveryId != null) {
+            delivery = deliveryRepository.findById(deliveryId)
+                    .orElseThrow(() -> new CustomException(DELIVERY_NOT_FOUND));
+        } else if (dailyId != null) {
+            daily = dailyRepository.findById(dailyId)
+                    .orElseThrow(() -> new CustomException(DAILY_NOT_FOUND));
+        } else if (marketId != null) {
+            market = marketRepository.findById(marketId)
+                    .orElseThrow(() -> new CustomException(MARKET_NOT_FOUND));
+        } else if (commentId != null) {
+            comment = commentRepository.findById(commentId)
+                    .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+        } else {
+            throw new CustomException(LIKE_TARGET_NOT_SELECTED);
+        }
+
+        Like like = LikeDto.LikeRequest.toEntity(user, delivery, daily, market, comment);
+        likeRepository.save(like);
+    }
+}

--- a/src/main/java/com/duktown/domain/like/service/LikeService.java
+++ b/src/main/java/com/duktown/domain/like/service/LikeService.java
@@ -18,6 +18,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+
 import static com.duktown.global.exception.CustomErrorType.*;
 
 @Service
@@ -33,6 +36,17 @@ public class LikeService {
 
     // 좋아요 추가, 취소
     public LikeDto.LikeResponse like(Long userId, LikeDto.LikeRequest request) {
+        // null이 아닌 필드가 여러 개일 때 -> 잘못된 좋아요 요청
+        if (Stream.of(
+                        request.getDeliveryId(),
+                        request.getDailyId(),
+                        request.getMarketId(),
+                        request.getCommentId())
+                .filter(Objects::nonNull)
+                .count() >= 2) {
+            throw new CustomException(LIKE_TARGET_ERROR);
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 

--- a/src/main/java/com/duktown/domain/like/service/LikeService.java
+++ b/src/main/java/com/duktown/domain/like/service/LikeService.java
@@ -37,7 +37,7 @@ public class LikeService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 좋아요 존재 시 취소
-        Like findLike = null;
+        Like findLike;
 
         if(request.getDeliveryId() != null) {
             findLike = likeRepository.findByUserIdAndDeliveryId(userId, request.getDeliveryId());
@@ -74,6 +74,9 @@ public class LikeService {
         } else if (request.getCommentId() != null) {
             comment = commentRepository.findById(request.getCommentId())
                     .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+            if(comment.getDeleted()) {
+                throw new CustomException(COMMENT_NOT_FOUND);
+            }
         } else {
             throw new CustomException(LIKE_TARGET_NOT_SELECTED);
         }

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -45,7 +45,10 @@ public enum CustomErrorType {
     COMMENT_NOT_FOUND(NOT_FOUND, 70001, "존재하지 않는 댓글입니다."),
     PARENT_COMMENT_NOT_FOUND(NOT_FOUND, 70002, "존재하지 않는 상위 댓글입니다."),
     COMMENT_TARGET_NOT_SELECTED(BAD_REQUEST, 70003, "댓글을 달 대상이 선택되지 않았습니다."),
-    COMMENT_DEPTH_ERROR(BAD_REQUEST, 70004, "대댓글에 대댓글을 달 수 없습니다.");
+    COMMENT_DEPTH_ERROR(BAD_REQUEST, 70004, "대댓글에 대댓글을 달 수 없습니다."),
+
+    // Like(8xxxx)
+    LIKE_TARGET_NOT_SELECTED(BAD_REQUEST, 80001, "좋아요할 대상이 선택되지 않았습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -46,7 +46,7 @@ public enum CustomErrorType {
     PARENT_COMMENT_NOT_FOUND(NOT_FOUND, 70002, "존재하지 않는 상위 댓글입니다."),
     COMMENT_TARGET_NOT_SELECTED(BAD_REQUEST, 70003, "댓글을 생성하거나 조회할 대상이 선택되지 않았습니다."),
     COMMENT_DEPTH_ERROR(BAD_REQUEST, 70004, "대댓글에 대댓글을 달 수 없습니다."),
-    COMMENT_TARGET_ERROR(BAD_REQUEST, 70005, "댓글을 달 대상은 하나만 선택할 수 있습니다."),
+    COMMENT_TARGET_ERROR(BAD_REQUEST, 70005, "댓글을 생성하거나 조회할 대상은 하나만 선택할 수 있습니다."),
 
     // Like(8xxxx)
     LIKE_TARGET_NOT_SELECTED(BAD_REQUEST, 80001, "좋아요할 대상이 선택되지 않았습니다."),

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -44,11 +44,13 @@ public enum CustomErrorType {
     // Comment(7xxxx)
     COMMENT_NOT_FOUND(NOT_FOUND, 70001, "존재하지 않는 댓글입니다."),
     PARENT_COMMENT_NOT_FOUND(NOT_FOUND, 70002, "존재하지 않는 상위 댓글입니다."),
-    COMMENT_TARGET_NOT_SELECTED(BAD_REQUEST, 70003, "댓글을 달 대상이 선택되지 않았습니다."),
+    COMMENT_TARGET_NOT_SELECTED(BAD_REQUEST, 70003, "댓글을 생성하거나 조회할 대상이 선택되지 않았습니다."),
     COMMENT_DEPTH_ERROR(BAD_REQUEST, 70004, "대댓글에 대댓글을 달 수 없습니다."),
+    COMMENT_TARGET_ERROR(BAD_REQUEST, 70005, "댓글을 달 대상은 하나만 선택할 수 있습니다."),
 
     // Like(8xxxx)
-    LIKE_TARGET_NOT_SELECTED(BAD_REQUEST, 80001, "좋아요할 대상이 선택되지 않았습니다.");
+    LIKE_TARGET_NOT_SELECTED(BAD_REQUEST, 80001, "좋아요할 대상이 선택되지 않았습니다."),
+    LIKE_TARGET_ERROR(BAD_REQUEST, 80002, "좋아요할 대상은 하나만 선택할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;


### PR DESCRIPTION
## 📝 PR 내용
좋아요와 관련된 기능을 구현했습니다.
- 익명 게시판을 기반으로 구현하므로, 좋아요한 사람들 목록 조회 등은 구현하지 않았습니다.
- 다만, 현재 로그인한 사용자가 게시글/댓글에 대해 좋아요한 여부 표시에 대한 기능은 구현했습니다.
-> 댓글은 완료하였고, 게시글은 일상, 장터 하나로 합치는 작업 이후 진행 예정입니다.
- POST로 추가, 취소를 한번에 처리하도록 구현했습니다.
- 테스트 코드는 나중에 따로 작성할 예정입니다.
- 댓글 삭제 시 좋아요도 함께 삭제됩니다.
- deleted가 true인 댓글은 좋아요하지 못하도록 구현

## 관련 이슈
close #17 
