### PR TITLE
[REFACTOR #18] 일상 글 삭제 시 댓글도 삭제로 수정

### DIFF
--- a/src/main/java/com/duktown/domain/daily/entity/Daily.java
+++ b/src/main/java/com/duktown/domain/daily/entity/Daily.java
@@ -1,6 +1,7 @@
 package com.duktown.domain.daily.entity;
 
 import com.duktown.domain.BaseTimeEntity;
+import com.duktown.domain.comment.entity.Comment;
 import com.duktown.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,6 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PRIVATE;
@@ -33,6 +37,9 @@ public class Daily extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "longtext")
     private String content;
+
+    @OneToMany(mappedBy = "daily")
+    private List<Comment> Comments = new ArrayList<>();
 
     public void update(String title, String content){
         this.title =title;


### PR DESCRIPTION
## 📝 PR 내용
일상 글 삭제 시 댓글 도 삭제되도록 구현하였습니다.
수정된 파일은 아래와 같습니다.
1. ERD를 바탕으로 Daily 엔티티에 OneToMany로 댓글 칼럼 추가
2. DailyService 파일 deleteDaily 메소드 수정

## 관련 이슈
close #18 
