### PR TITLE
Feature/#17 게시글 좋아요 여부, 개수 표시/ 배달팟 좋아요 제거

### DIFF
--- a/src/main/java/com/duktown/domain/comment/service/CommentService.java
+++ b/src/main/java/com/duktown/domain/comment/service/CommentService.java
@@ -77,6 +77,8 @@ public class CommentService {
     // TODO: queryDsl 도입해 대댓글 조회 기능 수정
     @Transactional(readOnly = true)
     public CommentDto.ListResponse getCommentList(Long userId, Long deliveryId, Long postId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
         // null이 아닌 필드가 여러 개일 때(대댓글 경우 제외) -> 잘못된 댓글 요청
         if (Stream.of(
                         deliveryId,
@@ -95,7 +97,7 @@ public class CommentService {
             commentCount = commentRepository.countByDeliveryId(deliveryId);
             likes = likeRepository
                     .findAllByUserAndCommentIn(
-                            userId,
+                            user.getId(),
                             commentRepository.findAllByDeliveryId(deliveryId)
                                     .stream().map(Comment::getId)
                                     .collect(Collectors.toList())
@@ -105,7 +107,7 @@ public class CommentService {
             commentCount = commentRepository.countByPostId(postId);
             likes = likeRepository
                     .findAllByUserAndCommentIn(
-                            userId,
+                            user.getId(),
                             commentRepository.findAllByPostId(postId)
                                     .stream().map(Comment::getId)
                                     .collect(Collectors.toList())

--- a/src/main/java/com/duktown/domain/like/dto/LikeDto.java
+++ b/src/main/java/com/duktown/domain/like/dto/LikeDto.java
@@ -2,7 +2,6 @@ package com.duktown.domain.like.dto;
 
 import com.duktown.domain.comment.entity.Comment;
 import com.duktown.domain.post.entity.Post;
-import com.duktown.domain.delivery.entity.Delivery;
 import com.duktown.domain.like.entity.Like;
 import com.duktown.domain.user.entity.User;
 import lombok.AllArgsConstructor;
@@ -15,14 +14,12 @@ public class LikeDto {
     @NoArgsConstructor
     @Getter
     public static class LikeRequest {
-        private Long deliveryId;
         private Long postId;
         private Long commentId;
 
-        public static Like toEntity(User user, Delivery delivery, Post post, Comment comment) {
+        public static Like toEntity(User user, Post post, Comment comment) {
             return Like.builder()
                     .user(user)
-                    .delivery(delivery)
                     .post(post)
                     .comment(comment)
                     .build();

--- a/src/main/java/com/duktown/domain/like/entity/Like.java
+++ b/src/main/java/com/duktown/domain/like/entity/Like.java
@@ -3,7 +3,6 @@ package com.duktown.domain.like.entity;
 import com.duktown.domain.BaseTimeEntity;
 import com.duktown.domain.comment.entity.Comment;
 import com.duktown.domain.post.entity.Post;
-import com.duktown.domain.delivery.entity.Delivery;
 import com.duktown.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,10 +30,6 @@ public class Like extends BaseTimeEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "delivery_id")
-    private Delivery delivery;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "daily_id")

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -34,4 +34,12 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Modifying
     @Query("delete from Like l where l.comment.id = :commentId")
     void deleteByCommentId(@Param("commentId") Long commentId);
+
+    @Modifying
+    @Query(value = "delete from Like l where l.comment.id in :commentIds")
+    void deleteByCommentIn(@Param("commentIds") List<Long> commentIds);
+
+    @Modifying
+    @Query("delete from Like l where l.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -1,5 +1,7 @@
 package com.duktown.domain.like.entity;
 
+import com.duktown.domain.post.entity.Post;
+import com.duktown.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -22,6 +24,14 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             "where l.user.id = :userId " +
             "and l.comment.id in :commentIds")
     List<Like> findAllByUserAndCommentIn(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
+
+    @Query("select l from Like l " +
+            "join fetch l.post p " +
+            "where l.user.id = :userId " +
+            "and l.post.id in :postIds")
+    List<Like> findAllByUserAndPostIn(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
+
+    List<Like> findAllByUserAndPost(User user, Post post);
 
     @Modifying
     @Query("delete from Like l where l.comment.id = :commentId")

--- a/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/duktown/domain/like/entity/LikeRepository.java
@@ -13,8 +13,6 @@ import java.util.List;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    Like findByUserIdAndDeliveryId(Long userId, Long deliveryId);
-
     Like findByUserIdAndPostId(Long userId, Long postId);
 
     Like findByUserIdAndCommentId(Long userId, Long commentId);

--- a/src/main/java/com/duktown/domain/post/controller/PostController.java
+++ b/src/main/java/com/duktown/domain/post/controller/PostController.java
@@ -26,14 +26,18 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<PostDto.PostListResponse> getPostList(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam(value = "category") Integer category
     ){
-        return ResponseEntity.ok().body(postService.getPostList(category));
+        return ResponseEntity.ok().body(
+                postService.getPostList(customUserDetails.getId(), category));
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDto.PostResponse> getPost(@PathVariable("postId") Long id){
-        return ResponseEntity.ok().body(postService.getPost(id));
+    public ResponseEntity<PostDto.PostResponse> getPost(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable("postId") Long postId){
+        return ResponseEntity.ok().body(postService.getPost(customUserDetails.getId(), postId));
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/com/duktown/domain/post/controller/PostController.java
+++ b/src/main/java/com/duktown/domain/post/controller/PostController.java
@@ -52,8 +52,8 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable("postId") Long id){
-        postService.deletePost(customUserDetails.getId(), id);
+            @PathVariable("postId") Long postId){
+        postService.deletePost(customUserDetails.getId(), postId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/duktown/domain/post/dto/PostDto.java
+++ b/src/main/java/com/duktown/domain/post/dto/PostDto.java
@@ -1,5 +1,6 @@
 package com.duktown.domain.post.dto;
 
+import com.duktown.domain.like.entity.Like;
 import com.duktown.domain.post.entity.Post;
 import com.duktown.domain.user.entity.User;
 import com.duktown.global.type.Category;
@@ -46,14 +47,18 @@ public class PostDto {
         private Integer category;
         private String title;
         private String content;
+        private Boolean liked;
+        private Integer likeCount;
         private String datetime;
 
-        public PostResponse(Post post){
+        public PostResponse(Post post, List<Like> likes){
             this.id = post.getId();
             this.userId = post.getUser().getId();
             this.category = post.getCategory().getValue();
             this.title = post.getTitle();
             this.content = post.getContent();
+            this.liked = likes.stream().anyMatch(l -> l.getPost().getId().equals(post.getId()));
+            this.likeCount = post.getLikes().size();
             this.datetime = DateUtil.convert(post.getCreatedAt());
         }
     }

--- a/src/main/java/com/duktown/domain/post/entity/Post.java
+++ b/src/main/java/com/duktown/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package com.duktown.domain.post.entity;
 
 import com.duktown.domain.BaseTimeEntity;
 import com.duktown.domain.comment.entity.Comment;
+import com.duktown.domain.like.entity.Like;
 import com.duktown.domain.user.entity.User;
 import com.duktown.global.type.Category;
 import lombok.AllArgsConstructor;
@@ -45,7 +46,10 @@ public class Post extends BaseTimeEntity {
     private String content;
 
     @OneToMany(mappedBy = "post")
-    private List<Comment> Comments = new ArrayList<>();
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<Like> likes = new ArrayList<>();
 
     public void update(String title, String content){
         this.title =title;

--- a/src/main/java/com/duktown/domain/post/service/PostService.java
+++ b/src/main/java/com/duktown/domain/post/service/PostService.java
@@ -1,6 +1,8 @@
 package com.duktown.domain.post.service;
 
 import com.duktown.domain.comment.entity.CommentRepository;
+import com.duktown.domain.like.entity.Like;
+import com.duktown.domain.like.entity.LikeRepository;
 import com.duktown.domain.post.dto.PostDto;
 import com.duktown.domain.post.entity.Post;
 import com.duktown.domain.post.entity.PostRespository;
@@ -25,6 +27,7 @@ public class PostService {
     private final PostRespository postRespository;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
 
     // 생성
     public void createPost(Long userId, PostDto.PostRequest request){
@@ -41,21 +44,32 @@ public class PostService {
 
     // 상세 조회
     @Transactional(readOnly = true)
-    public PostDto.PostResponse getPost(Long id){
-        Post post = postRespository.findById(id).orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-        return new PostDto.PostResponse(post);
+    public PostDto.PostResponse getPost(Long userId, Long postId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Post post = postRespository.findById(postId).orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+        List<Like> likes = likeRepository.findAllByUserAndPost(user, post);
+        return new PostDto.PostResponse(post, likes);
     }
 
     // 목록 조회
     @Transactional(readOnly = true)
-    public PostDto.PostListResponse getPostList(Integer category) {
+    public PostDto.PostListResponse getPostList(Long userId, Integer category) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
         Category findCategory = Arrays.stream(Category.values())
                 .filter(c -> c.getValue() == category)
                 .findAny().orElseThrow(() -> new CustomException(INVALID_POST_CATEGORY_VALUE));
 
         List<Post> posts = postRespository.findAllByCategory(findCategory);
+        List<Like> likes = likeRepository
+                .findAllByUserAndPostIn(
+                        user.getId(),
+                        posts.stream().map(Post::getId)
+                                .collect(Collectors.toList())
+                );
+
         List<PostDto.PostResponse> postListResponses = posts.stream()
-                .map(PostDto.PostResponse::new)
+                .map(p -> new PostDto.PostResponse(p, likes))
                 .collect(Collectors.toList());
 
         return new PostDto.PostListResponse(postListResponses);

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -39,8 +39,7 @@ public enum CustomErrorType {
     POST_NOT_FOUND(NOT_FOUND, 50001, "존재하지 않는 게시글입니다."),
     INVALID_POST_CATEGORY_VALUE(BAD_REQUEST,50002, "잘못된 카테고리입니다."),
 
-    // Market(6xxxx)
-    MARKET_NOT_FOUND(NOT_FOUND, 60001, "존재하지 않는 장터글입니다."),
+    // (6xxxx)
 
     // Comment(7xxxx)
     COMMENT_NOT_FOUND(NOT_FOUND, 70001, "존재하지 않는 댓글입니다."),


### PR DESCRIPTION
## 📝 PR 내용
게시글 삭제 시 댓글과 좋아요 먼저 삭제되도록 구현했습니다.
기획에 따라 배달팟 좋아요를 불가하도록 수정했습니다.
게시글 조회 시 좋아요 여부, 개수가 표시되도록 변경했습니다.

## 관련 이슈
close #17 
