### PR TITLE
[REFACTOR #31] 응집성이 높이기 위해SecurityConfig와 WebConfig로 분리하기

### DIFF
--- a/src/main/java/com/duktown/global/WebConfig.java
+++ b/src/main/java/com/duktown/global/WebConfig.java
@@ -1,0 +1,16 @@
+package com.duktown.global;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("OPTIONS","GET", "POST", "PUT", "PATCH", "DELETE");
+    }
+}

--- a/src/main/java/com/duktown/global/security/SecurityConfig.java
+++ b/src/main/java/com/duktown/global/security/SecurityConfig.java
@@ -18,12 +18,10 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.firewall.DefaultHttpFirewall;
 import org.springframework.security.web.firewall.HttpFirewall;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
 
-import static org.springframework.security.config.http.SessionCreationPolicy.*;
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -78,17 +76,6 @@ public class SecurityConfig {
         return http.build();
     }
 
-    @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000")
-                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE");
-            }
-        };
-    }
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {


### PR DESCRIPTION
## 📝 PR 내용
1. 응집성을  높이기 위해 보안 관련 설정을 SecurityConfig에서 하고, Spring MVC와 관련된 설정을 WebConfig에서 하도록 구성.
2. 전역 설정을 위해 WebConfig로 구성


## 관련 이슈
#31 
