### PR TITLE
Feature/#9 이메일 인증 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### yml file ###
+application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     // MySQL Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/duktown/domain/emailCert/dto/EmailCertDto.java
+++ b/src/main/java/com/duktown/domain/emailCert/dto/EmailCertDto.java
@@ -1,0 +1,51 @@
+package com.duktown.domain.emailCert.dto;
+
+import com.duktown.domain.emailCert.entity.EmailCert;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+
+public class EmailCertDto {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class EmailRequest {  // 이메일 인증 request
+        @NotEmpty(message = "이메일은 필수 값입니다.")
+        @Email(regexp = "^[a-zA-Z0-9\\.][^@]+\\@duksung.ac.kr$",
+                message = "이메일 형식이 올바르지 않습니다. 덕성 이메일을 입력해주세요.")
+        private String email;
+    }
+
+    // 이메일 체크 응답
+    @Getter
+    @AllArgsConstructor
+    public static class EmailResponse {
+        private Boolean isDuplicated;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CertRequest {   // 인증 번호 확인 request
+        @NotEmpty(message = "이메일은 필수 값입니다.")
+        @Email(regexp = "^[a-zA-Z0-9\\.][^@]+\\@duksung.ac.kr$",
+                message = "이메일 형식이 올바르지 않습니다. 덕성 이메일을 입력해주세요.")
+        private String email;
+        @NotBlank(message = "인증 코드는 필수 값입니다.")
+        private String certCode;
+
+        public EmailCert toEntity() {
+            return EmailCert.builder()
+                    .email(email)
+                    .certCode(certCode)
+                    .certified(false)   // 최초 저장시 기본 false
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/duktown/domain/emailCert/entity/EmailCert.java
+++ b/src/main/java/com/duktown/domain/emailCert/entity/EmailCert.java
@@ -30,5 +30,14 @@ public class EmailCert {
     @Column(nullable = false)
     private String certCode;
 
+    @Column(nullable = false)
     private Boolean certified;
+
+    public void updateCertCode(String certCode) {
+        this.certCode = certCode;
+    }
+
+    public void updateCertified(Boolean certified) {
+        this.certified = certified;
+    }
 }

--- a/src/main/java/com/duktown/domain/emailCert/entity/EmailCert.java
+++ b/src/main/java/com/duktown/domain/emailCert/entity/EmailCert.java
@@ -1,5 +1,6 @@
 package com.duktown.domain.emailCert.entity;
 
+import com.duktown.domain.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,7 @@ import static lombok.AccessLevel.PROTECTED;
 @AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "email_cert")
-public class EmailCert {
+public class EmailCert extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/duktown/domain/emailCert/entity/EmailCertRepository.java
+++ b/src/main/java/com/duktown/domain/emailCert/entity/EmailCertRepository.java
@@ -1,0 +1,11 @@
+package com.duktown.domain.emailCert.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailCertRepository extends JpaRepository<EmailCert, Long> {
+    Optional<EmailCert> findByEmail(String email);
+}

--- a/src/main/java/com/duktown/domain/emailCert/service/EmailCertService.java
+++ b/src/main/java/com/duktown/domain/emailCert/service/EmailCertService.java
@@ -1,0 +1,123 @@
+package com.duktown.domain.emailCert.service;
+
+import com.duktown.domain.emailCert.dto.EmailCertDto;
+import com.duktown.domain.emailCert.entity.EmailCert;
+import com.duktown.domain.emailCert.entity.EmailCertRepository;
+import com.duktown.domain.user.entity.User;
+import com.duktown.domain.user.entity.UserRepository;
+import com.duktown.global.email.MailService;
+import com.duktown.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+import static com.duktown.global.exception.CustomErrorType.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EmailCertService {
+    private final UserRepository userRepository;
+    private final EmailCertRepository emailCertRepository;
+    private final MailService mailService;
+
+    // 이메일로 인증번호 발송
+    public EmailCertDto.EmailResponse emailSend(EmailCertDto.EmailRequest request) {
+
+        // 이미 가입된 이메일이면, isDuplicated: true 응답
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElse(null);
+
+        if (user != null) {
+            return new EmailCertDto.EmailResponse(true);
+        }
+
+        String certCode = createCertNumber();
+        EmailCert emailCert = emailCertRepository.findByEmail(request.getEmail()).orElse(null);
+
+        // 기존 인증요청이 있었다면 인증번호만 업데이트
+        if (emailCert != null) {
+            emailCert.updateCertCode(certCode);
+        }
+        else {
+            EmailCertDto.CertRequest certRequest = new EmailCertDto.CertRequest(request.getEmail(), certCode);
+            emailCertRepository.save(certRequest.toEntity());
+        }
+
+        String subject = "[덕타운] 이메일 인증 코드를 발송해 드립니다.";
+        String text = "덕타운 서비스에 가입하기 위해 덕성 이메일 인증이 필요합니다.\n\n" +
+                "귀하가 인증 요청한 이메일이 맞으면 아래의 이메일 인증 코드를 입력해주세요.\n\n" +
+                certCode + "\n\n" +
+                "코드는 10분 후 만료됩니다.\n\n" +
+                "감사합니다.\n\n" +
+                "- 덕타운 운영팀";
+
+        // 비동기로 메일 전송 -> 응답을 빨리 보내 인증번호 입력 창으로 넘어가야 하기 때문
+        sendAsyncEmail(request.getEmail(), subject, text);
+
+        // 중복 x => 이메일 발송 후 isDuplicated : false 응답
+        return new EmailCertDto.EmailResponse(false);
+    }
+
+    // 이메일 인증
+    public void emailCert(EmailCertDto.CertRequest request) {
+        // 인증 요청 내역 조회 -> 인증요청을 한 적이 없거나, 10분 이상 지나면 조회 x
+        EmailCert emailCert = emailCertRepository.findByEmail(request.getEmail()).orElseThrow(
+                () -> new CustomException(EMAIL_CERT_NOT_FOUND)
+        );
+
+        // 입력한 코드와 인증코드가 같을 때
+        if (emailCert.getCertCode().equals(request.getCertCode())) {
+
+            // 인증 여부가 참일 때 이미 가입한 이메일인지 체크
+            if (emailCert.getCertified()) {
+                User user = userRepository.findByEmail(request.getEmail()).orElse(null);
+
+                if (user != null) {
+                    throw new CustomException(EMAIL_ALREADY_EXIST);
+                }
+            }
+
+            // 이메일 인증 성공
+            emailCert.updateCertified(true);
+
+        } else {
+            // 일치하지 않으면 인증 실패
+            throw new CustomException(EMAIL_CERT_FAILED);
+        }
+
+    }
+
+    // 인증번호 생성 메서드
+    private String createCertNumber() {
+        Random random = new Random();
+        random.setSeed(System.currentTimeMillis());
+
+        int count = 6;
+        StringBuilder certNumber = new StringBuilder();
+
+        for (int i=0; i<count; i++) {
+            certNumber.append(random.nextInt(9));
+        }
+
+        return certNumber.toString();
+    }
+
+    // 이메일 전송 비동기 처리
+    private void sendAsyncEmail(String to, String subject, String text) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        new Thread(
+                () -> {
+                    mailService.sendEmail(to, subject, text);
+                    log.debug("MailService.sendEmail finished at : {}", LocalDateTime.now());
+                    future.complete(null);
+                }
+        ).start();
+    }
+}

--- a/src/main/java/com/duktown/domain/user/controller/UserController.java
+++ b/src/main/java/com/duktown/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.duktown.domain.user.controller;
 
+import com.duktown.domain.emailCert.dto.EmailCertDto;
+import com.duktown.domain.emailCert.service.EmailCertService;
 import com.duktown.domain.user.dto.UserDto;
 import com.duktown.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +17,17 @@ import javax.validation.Valid;
 public class UserController {
 
     private final UserService userService;
+    private final EmailCertService emailCertService;
 
-    @PostMapping("/email-duplicate")
-    public ResponseEntity<UserDto.EmailCheckResponse> emailCheck(@Valid @RequestBody final UserDto.EmailCheckRequest emailCheckRequest) {
-        return ResponseEntity.ok(userService.emailCheck(emailCheckRequest));
+    @PostMapping("/email-cert")
+    public ResponseEntity<EmailCertDto.EmailResponse> emailCert(@Valid @RequestBody final EmailCertDto.EmailRequest request) {
+        return ResponseEntity.ok(emailCertService.emailSend(request));
+    }
+
+    @PostMapping("/email-cert/check")
+    public ResponseEntity<Void> emailCertCheck(@Valid @RequestBody final EmailCertDto.CertRequest request) {
+        emailCertService.emailCert(request);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/id-duplicate")

--- a/src/main/java/com/duktown/domain/user/dto/UserDto.java
+++ b/src/main/java/com/duktown/domain/user/dto/UserDto.java
@@ -39,17 +39,6 @@ public class UserDto {
         }
     }
 
-    // 이메일 체크 요청
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class EmailCheckRequest {
-        @NotEmpty(message = "이메일은 필수 값입니다.")
-        @Email(message = "이메일 형식이 올바르지 않습니다.")
-        @Pattern(regexp = "[A-Za-z0-9+_.-]+@duksung.ac.kr", message = "덕성 메일을 입력해주세요.")
-        private String email;
-    }
-
     // 아이디 중복 체크 요청
     @Getter
     @AllArgsConstructor
@@ -75,13 +64,6 @@ public class UserDto {
     public static class SignUpResponse {
         private String accessToken;
         private String refreshToken;
-    }
-
-    // 이메일 체크 응답
-    @Getter
-    @AllArgsConstructor
-    public static class EmailCheckResponse {
-        private Boolean isDuplicated;
     }
 
     // 아이디 체크 응답

--- a/src/main/java/com/duktown/domain/user/service/UserService.java
+++ b/src/main/java/com/duktown/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package com.duktown.domain.user.service;
 
+import com.duktown.domain.emailCert.entity.EmailCert;
+import com.duktown.domain.emailCert.entity.EmailCertRepository;
 import com.duktown.domain.user.dto.UserDto;
 import com.duktown.domain.user.entity.User;
 import com.duktown.domain.user.entity.UserRepository;
+import com.duktown.global.exception.CustomErrorType;
 import com.duktown.global.exception.CustomException;
 import com.duktown.global.security.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -19,20 +22,9 @@ import static com.duktown.global.exception.CustomErrorType.LOGIN_ID_ALREADY_EXIS
 public class UserService {
 
     private final UserRepository userRepository;
+    private final EmailCertRepository emailCertRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
-
-    // 이메일 중복 체크 메서드
-    @Transactional(readOnly = true)
-    public UserDto.EmailCheckResponse emailCheck(UserDto.EmailCheckRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElse(null);
-
-        if (user != null) {
-            return new UserDto.EmailCheckResponse(true);
-        }
-        return new UserDto.EmailCheckResponse(false);
-    }
 
     // 아이디 중복 체크 메서드
     @Transactional(readOnly = true)
@@ -59,7 +51,14 @@ public class UserService {
         // 아이디 중복 체크
         idDuplicateCheck(signupRequest.getLoginId());
 
-        // TODO: 이메일 인증 여부 체크
+        // 이메일 인증 여부 체크
+//        EmailCert emailCert = emailCertRepository.findByEmail(signupRequest.getEmail()).orElseThrow(
+//                () -> new CustomException(CustomErrorType.EMAIL_CERT_NOT_FOUND)
+//        );
+//
+//        if (!emailCert.getCertified()) {
+//            throw new CustomException(CustomErrorType.EMAIL_CERT_FAILED);
+//        }
 
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());

--- a/src/main/java/com/duktown/global/config/EmailConfig.java
+++ b/src/main/java/com/duktown/global/config/EmailConfig.java
@@ -1,0 +1,67 @@
+package com.duktown.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/duktown/global/config/ProjectConfig.java
+++ b/src/main/java/com/duktown/global/config/ProjectConfig.java
@@ -1,4 +1,4 @@
-package com.duktown.global;
+package com.duktown.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/duktown/global/config/SecurityConfig.java
+++ b/src/main/java/com/duktown/global/config/SecurityConfig.java
@@ -1,10 +1,11 @@
-package com.duktown.global.security;
+package com.duktown.global.config;
 
 import com.duktown.global.security.filter.JwtAuthenticationFilter;
 import com.duktown.global.security.filter.JwtAuthorizationFilter;
 import com.duktown.global.security.handler.JwtAccessDeniedHandler;
 import com.duktown.global.security.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -18,8 +19,12 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.firewall.DefaultHttpFirewall;
 import org.springframework.security.web.firewall.HttpFirewall;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
@@ -39,9 +44,12 @@ public class SecurityConfig {
     // TODO: 인증에 예외를 둘 로직 추가
     private static final String[] AUTH_WHITE_LIST = {
             "/auth/signup",
-            "/auth/email-duplicate",
+            "/auth/email-cert/**",
             "/auth/id-duplicate"
     };
+
+    @Value("${custom.cors.originUrl}")
+    private String originUrl;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -57,6 +65,8 @@ public class SecurityConfig {
                 .exceptionHandling()
                 .accessDeniedHandler(jwtAccessDeniedHandler)
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // exception handling
+                .and()
+                .cors().configurationSource(corsConfigurationSource()) // cors custom
                 .and()
                 .csrf().disable()
                 .formLogin().disable()
@@ -85,5 +95,22 @@ public class SecurityConfig {
     @Bean
     public HttpFirewall defaultHttpFirewall() {
         return new DefaultHttpFirewall();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(List.of(originUrl));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L); // preflight 결과 1시간 동안 캐시에 저장
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
     }
 }

--- a/src/main/java/com/duktown/global/config/WebConfig.java
+++ b/src/main/java/com/duktown/global/config/WebConfig.java
@@ -1,4 +1,4 @@
-package com.duktown.global;
+package com.duktown.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/src/main/java/com/duktown/global/email/MailService.java
+++ b/src/main/java/com/duktown/global/email/MailService.java
@@ -1,0 +1,37 @@
+package com.duktown.global.email;
+
+import com.duktown.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.duktown.global.exception.CustomErrorType.UNABLE_TO_SEND_EMAIL;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MailService {
+    private final JavaMailSender javaMailSender;
+
+    // 발신 이메일 데이터 설정
+    private SimpleMailMessage createEmailForm(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+
+        return message;
+    }
+
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage emailForm = createEmailForm(to, subject, text);
+        try {
+            javaMailSender.send(emailForm);
+        } catch (RuntimeException e) {
+            throw new CustomException(UNABLE_TO_SEND_EMAIL);
+        }
+    }
+}

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -39,7 +39,10 @@ public enum CustomErrorType {
     POST_NOT_FOUND(NOT_FOUND, 50001, "존재하지 않는 게시글입니다."),
     INVALID_POST_CATEGORY_VALUE(BAD_REQUEST,50002, "잘못된 카테고리입니다."),
 
-    // (6xxxx)
+    // Cert (6xxxx) 인증 오류
+    UNABLE_TO_SEND_EMAIL(INTERNAL_SERVER_ERROR, 60001, "이메일을 전송할 수 없습니다."),
+    EMAIL_CERT_NOT_FOUND(NOT_FOUND, 60002, "이메일 인증 내역이 존재하지 않습니다."),
+    EMAIL_CERT_FAILED(UNAUTHORIZED, 60003, "인증번호가 일치하지 않습니다."),
 
     // Comment(7xxxx)
     COMMENT_NOT_FOUND(NOT_FOUND, 70001, "존재하지 않는 댓글입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,33 +1,23 @@
 # DB
 spring:
+  profiles:
+    include: local
   datasource:
     # local-mysql-db-test
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/duktown?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: duktown
     password: 1234
-  # local-h2-db-test
-#    driver-class-name: org.h2.Driver
-#    url: jdbc:h2:tcp://localhost/~/duktown
-#    username: sa
-#    password:
+
   # JPA
   jpa:
     properties:
       hibernate:
         show_sql: true
         format_sql: true
-    hibernate:
-      ddl-auto: create
 
 # Logging level
 logging:
   level:
     com:
       duktown: debug
-
-# JWT
-custom:
-  jwt:
-    secret-key:
-      custom_jwt_secret_key_for_local_test_secret_key_secret_secret_key

--- a/src/test/java/com/duktown/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/com/duktown/unit/user/controller/UserControllerTest.java
@@ -1,9 +1,10 @@
 package com.duktown.unit.user.controller;
 
+import com.duktown.domain.emailCert.dto.EmailCertDto;
 import com.duktown.domain.user.controller.UserController;
 import com.duktown.domain.user.dto.UserDto;
 import com.duktown.domain.user.service.UserService;
-import com.duktown.global.security.SecurityConfig;
+import com.duktown.global.config.SecurityConfig;
 import com.duktown.global.security.filter.JwtAuthorizationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -45,94 +46,7 @@ public class UserControllerTest {
     @MockBean
     private UserService userService;
 
-    @DisplayName("이메일 중복 체크 성공")
-    @WithMockUser
-    @Test
-    void emailDuplicateCheck_success() throws Exception {
-        // given
-        final String url = "/auth/email-duplicate";
-        final String email = "dskim@duksung.ac.kr";
-        UserDto.EmailCheckRequest request = new UserDto.EmailCheckRequest(email);
-        String body = new ObjectMapper().writeValueAsString(request);   // serialize
-
-        // when & then
-        mockMvc.perform(post(url)
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .content(body)
-                        .with(csrf()))  // csrf token
-                .andExpect(status().isOk())
-                .andDo(print());    // 처리 내용 출력
-    }
-
-    @DisplayName("이메일 중복 체크 api에서 requestBody가 없으면 실패")
-    @WithMockUser
-    @Test
-    void emailDuplicateCheck_noBody_fail() throws Exception {
-        // given
-        final String url = "/auth/email-duplicate";
-
-        // when & then
-        mockMvc.perform(post(url)
-                .with(csrf()))
-                .andExpect(status().isInternalServerError())
-                .andDo(print());
-    }
-
-    @DisplayName("이메일 중복 체크 api에서 이메일 입력하지 않으면 실패")
-    @WithMockUser
-    @Test
-    void emailDuplicateCheck_noEmail_fail() throws Exception {
-        // given
-        final String url = "/auth/email-duplicate";
-        UserDto.EmailCheckRequest request = new UserDto.EmailCheckRequest();
-        String body = new ObjectMapper().writeValueAsString(request);
-
-        // when & then
-        mockMvc.perform(post(url)
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .content(body)
-                        .with(csrf()))
-                .andExpect(status().is4xxClientError())
-                .andDo(print());
-    }
-
-    @DisplayName("이메일 중복 체크 api에서 덕성 이메일 아닐 시 실패")
-    @WithMockUser
-    @Test
-    void emailDuplicateCheck_notDuksungEmail_fail() throws Exception {
-        // given
-        final String url = "/auth/email-duplicate";
-        final String email = "dskim@gmail.com";
-        UserDto.EmailCheckRequest request = new UserDto.EmailCheckRequest(email);
-        String body = new ObjectMapper().writeValueAsString(request);
-
-        // when & then
-        mockMvc.perform(post(url)
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .content(body)
-                        .with(csrf()))
-                .andExpect(status().is4xxClientError())
-                .andDo(print());
-    }
-
-    @DisplayName("이메일 중복 체크 api에서 이메일 유효하지 않을 시 실패")
-    @WithMockUser
-    @Test
-    void emailDuplicateCheck_notValidEmail_fail() throws Exception {
-        // given
-        final String url = "/auth/email-duplicate";
-        final String email = "@duksung.ac.kr";
-        UserDto.EmailCheckRequest request = new UserDto.EmailCheckRequest(email);
-        String body = new ObjectMapper().writeValueAsString(request);
-
-        // when & then
-        mockMvc.perform(post(url)
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .content(body)
-                        .with(csrf()))
-                .andExpect(status().is4xxClientError())
-                .andDo(print());
-    }
+    // TODO: 이메일 인증 테스트 추가
 
     @DisplayName("아이디 중복 체크 성공")
     @WithMockUser

--- a/src/test/java/com/duktown/unit/user/service/UserServiceTest.java
+++ b/src/test/java/com/duktown/unit/user/service/UserServiceTest.java
@@ -56,35 +56,6 @@ public class UserServiceTest {
                 .build();
     }
 
-    @DisplayName("이메일 중복 체크 성공 - 중복 이메일 존재 x")
-    @Test
-    void duplicatedEmailNotExist_success(){
-        // given
-        given(userRepository.findByEmail(any())).willReturn(Optional.empty());
-        UserDto.EmailCheckRequest request = new UserDto.EmailCheckRequest("dskim@duksung.ac.kr");
-
-        // when
-        UserDto.EmailCheckResponse response = userService.emailCheck(request);
-
-        //then
-        assertThat(response.getIsDuplicated()).isEqualTo(false);
-    }
-
-    @DisplayName("이메일 중복 체크 성공 - 중복 이메일 존재")
-    @Test
-    void duplicatedEmailExist_success() {
-        // given
-        User user = createMockUser(1L);
-        given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
-        UserDto.EmailCheckRequest request = new UserDto.EmailCheckRequest(user.getEmail());
-
-        // when
-        UserDto.EmailCheckResponse response = userService.emailCheck(request);
-
-        // then
-        assertThat(response.getIsDuplicated()).isEqualTo(true);
-    }
-
     @DisplayName("아이디 중복 체크 성공 - 중복 아이디 존재 x")
     @Test
     void duplicatedLoginIdNotExist_success() {


### PR DESCRIPTION
## 📝 PR 내용
이메일 중복체크 엔드포인트를 제거하고 이메일 인증 요청(인증코드 발송)에서 이메일 중복도 함께 처리하도록 구현했습니다.

**/auth/email-cert**
- 이메일 입력받음
- 중복 시 isDuplicated : true를 응답
- 중복 x시 isDuplicated : true 응답, 비동기로 이메일 전송

**/auth/email-cert/check** 
- 이메일과 이메일로 전송된 인증코드 입력
- 일치 시 200 OK
- 일치 x시 60003번 에러코드


## 관련 이슈
close #9 
