### PR TITLE
Feature/#28  외박 신청 기능 추가에 따른 추가 구현

### DIFF
--- a/src/main/java/com/duktown/domain/sleepoverApply/controller/SleepoverApplyController.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/controller/SleepoverApplyController.java
@@ -44,7 +44,7 @@ public class SleepoverApplyController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/MANAGER")
+    @GetMapping("/manager")
     public ResponseEntity<SleepoverApplyDto.ResponseGetListSleepoverApply> getSleepoverList(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){

--- a/src/main/java/com/duktown/domain/sleepoverApply/controller/SleepoverApplyController.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/controller/SleepoverApplyController.java
@@ -25,9 +25,15 @@ public class SleepoverApplyController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    //    public ResponseEntity<?> updateSleepoverApply(Long sleepoverApplyId){
-//
-//    }
+    @PutMapping("/{sleepoverId}")
+    public ResponseEntity<?> updateSleepoverApply(
+            @PathVariable Long sleepoverId,
+            @RequestBody SleepoverApplyDto.RequestSleepoverApplyDto updateRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails)
+    {
+        sleepoverApplyService.updateSleepoverApply(customUserDetails.getId(),sleepoverId,updateRequest);
+        return ResponseEntity.ok().build();
+    }
 
     @DeleteMapping("/{sleepoverId}")
     public ResponseEntity<Void> deleteSleepoverApply(
@@ -38,7 +44,7 @@ public class SleepoverApplyController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping()
+    @GetMapping("/MANAGER")
     public ResponseEntity<SleepoverApplyDto.ResponseGetListSleepoverApply> getSleepoverList(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
@@ -46,11 +52,11 @@ public class SleepoverApplyController {
     }
 
     @GetMapping("/{sleepoverId}")
-    public ResponseEntity<SleepoverApplyDto.ResponseGetSleepoverApply> getList(
+    public ResponseEntity<SleepoverApplyDto.ResponseGetSleepoverApply> getSleepoverDetail(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long sleepoverId
     ){
-        return ResponseEntity.ok(sleepoverApplyService.getSleepoverApply(sleepoverId));
+        return ResponseEntity.ok(sleepoverApplyService.getDetailSleepoverApply(sleepoverId));
     }
 
     @PatchMapping("/{sleepoverApplyId}")

--- a/src/main/java/com/duktown/domain/sleepoverApply/controller/SleepoverApplyController.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/controller/SleepoverApplyController.java
@@ -28,7 +28,7 @@ public class SleepoverApplyController {
     @PutMapping("/{sleepoverId}")
     public ResponseEntity<?> updateSleepoverApply(
             @PathVariable Long sleepoverId,
-            @RequestBody SleepoverApplyDto.RequestSleepoverApplyDto updateRequest,
+            @Valid@RequestBody SleepoverApplyDto.RequestSleepoverApplyDto updateRequest,
             @AuthenticationPrincipal CustomUserDetails customUserDetails)
     {
         sleepoverApplyService.updateSleepoverApply(customUserDetails.getId(),sleepoverId,updateRequest);

--- a/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
@@ -8,9 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.*;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -22,8 +20,10 @@ public class SleepoverApplyDto extends BaseTimeEntity {
     public static class RequestSleepoverApplyDto{
 
         @NotNull
+        @FutureOrPresent(message = "외박 신청 날짜는 현재 시간 이후거나 동일해야 합니다.")
         private LocalDate startDate; //외박 시작 날짜
         @NotNull
+        @Future(message = "귀가 날짜는 미래여야 합니다.")
         private LocalDate endDate; //돌아오는 날짜
 
         @Min(value = 1)

--- a/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
@@ -29,8 +29,9 @@ public class SleepoverApplyDto extends BaseTimeEntity {
 
         @Min(value = 1)
         private Integer period; //외박 일 수
+
+        private String zipcode; // 우편번호
         @NotBlank(message = "머무는 곳의 주소는 필수 값입니다")
-        private String zipcode;
         private String streetAddress;// 지번 주소
         private String detailAddress;// 상세 주소
         @NotBlank(message = "사유는 필수 값입니다.")
@@ -42,7 +43,7 @@ public class SleepoverApplyDto extends BaseTimeEntity {
                     .startDate(startDate)
                     .endDate(endDate)
                     .period(period)
-                    .address(zipcode+streetAddress+detailAddress)
+                    .address(streetAddress)
                     .reason(reason)
                     .approved(ApprovalType.Waiting)
                     .build();

--- a/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
@@ -30,7 +30,9 @@ public class SleepoverApplyDto extends BaseTimeEntity {
         @Min(value = 1)
         private Integer period; //외박 일 수
         @NotBlank(message = "머무는 곳의 주소는 필수 값입니다")
-        private String address; // 머무르는 주소
+        private String zipcode;
+        private String streetAddress;// 지번 주소
+        private String detailAddress;// 상세 주소
         @NotBlank(message = "사유는 필수 값입니다.")
         private String reason; //사유
 
@@ -40,19 +42,12 @@ public class SleepoverApplyDto extends BaseTimeEntity {
                     .startDate(startDate)
                     .endDate(endDate)
                     .period(period)
-                    .address(address)
+                    .address(zipcode+streetAddress+detailAddress)
                     .reason(reason)
                     .approved(ApprovalType.Waiting)
                     .build();
         }
     }
-
-
-    @Getter
-    public static class RequestApproveSleepoverApply{
-        private ApprovalType approved;
-    }
-
 
 
     @Getter

--- a/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/dto/SleepoverApplyDto.java
@@ -3,6 +3,7 @@ package com.duktown.domain.sleepoverApply.dto;
 import com.duktown.domain.BaseTimeEntity;
 import com.duktown.domain.sleepoverApply.entity.SleepoverApply;
 import com.duktown.domain.user.entity.User;
+import com.duktown.global.type.ApprovalType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,9 +42,18 @@ public class SleepoverApplyDto extends BaseTimeEntity {
                     .period(period)
                     .address(address)
                     .reason(reason)
+                    .approved(ApprovalType.Waiting)
                     .build();
         }
     }
+
+
+    @Getter
+    public static class RequestApproveSleepoverApply{
+        private ApprovalType approved;
+    }
+
+
 
     @Getter
     @Builder
@@ -82,11 +92,6 @@ public class SleepoverApplyDto extends BaseTimeEntity {
         }
     }
 
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class RequestApproveSleepoverApply{
-        private Boolean approved;
-    }
+
 
 }

--- a/src/main/java/com/duktown/domain/sleepoverApply/entity/ApprovalType.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/entity/ApprovalType.java
@@ -1,0 +1,17 @@
+package com.duktown.domain.sleepoverApply.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApprovalType {
+// 승인, 대기, 반려
+Waiting(0,"대기"),
+Refuse(1,"반려"),
+Approved(2,"승인");
+
+private final int value;
+private final String ApprovalType;
+
+}

--- a/src/main/java/com/duktown/domain/sleepoverApply/entity/EnumApproved.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/entity/EnumApproved.java
@@ -1,5 +1,0 @@
-package com.duktown.domain.sleepoverApply.entity;
-
-public enum EnumApproved {
-// 승인, 대기, 반려
-}

--- a/src/main/java/com/duktown/domain/sleepoverApply/entity/SleepoverApply.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/entity/SleepoverApply.java
@@ -42,6 +42,7 @@ public class SleepoverApply {
     @Column(nullable = false)
     private String address; // 머무르는 주소
 
+
     @Column(nullable = false)
     private String reason; //사유
 

--- a/src/main/java/com/duktown/domain/sleepoverApply/entity/SleepoverApply.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/entity/SleepoverApply.java
@@ -1,12 +1,14 @@
 package com.duktown.domain.sleepoverApply.entity;
 
 import com.duktown.domain.user.entity.User;
+import com.duktown.global.type.ApprovalType;
 import lombok.*;
 
 import javax.persistence.*;
 
 import java.time.LocalDate;
 
+import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PRIVATE;
@@ -43,9 +45,19 @@ public class SleepoverApply {
     @Column(nullable = false)
     private String reason; //사유
 
-    private Boolean approved; //승인 여부
+    @Enumerated(STRING)
+    private ApprovalType approved; //승인 여부
 
-    public void approve(boolean approved){
+    public void approve(ApprovalType approved){
         this.approved = approved;
     }
+
+    public void updateSleepoverApply(LocalDate startDate, LocalDate endDate,Integer period,String reason){
+        this.startDate = startDate;
+        this.endDate=endDate;
+        this.period =period;
+        this.reason=reason;
+    }
+
+
 }

--- a/src/main/java/com/duktown/domain/sleepoverApply/entity/SleepoverApply.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/entity/SleepoverApply.java
@@ -53,10 +53,11 @@ public class SleepoverApply {
         this.approved = approved;
     }
 
-    public void updateSleepoverApply(LocalDate startDate, LocalDate endDate,Integer period,String reason){
+    public void updateSleepoverApply(LocalDate startDate, LocalDate endDate,Integer period,String address,String reason){
         this.startDate = startDate;
         this.endDate=endDate;
         this.period =period;
+        this.address =address;
         this.reason=reason;
     }
 

--- a/src/main/java/com/duktown/domain/sleepoverApply/service/SleepoverApplyService.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/service/SleepoverApplyService.java
@@ -43,13 +43,17 @@ public class SleepoverApplyService {
     //TODO: 외박 신청 수정 -> 하루 추가-> 추가 신청-> 이전 내역과 병합
 
     // 외박 신청 수정 ->  하루 감소 => 기존 신청 이력을 수정
-    public void updateSleepoverApply(Long userId,Long sleepoverApplyId ,SleepoverApplyDto.RequestSleepoverApplyDto requestUpdate){
+    public void updateSleepoverApply(Long userId,Long sleepoverApplyId ,SleepoverApplyDto.RequestSleepoverApplyDto requestUpdateDto){
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new CustomException(USER_NOT_FOUND));
 
         SleepoverApply updateSleepover = sleepoverApplyRepository.findById(sleepoverApplyId)
                 .orElseThrow(()-> new CustomException(SLEEP_OVER_APPLY_NOT_FOUND));
-        updateSleepover.updateSleepoverApply(requestUpdate.getStartDate(),requestUpdate.getEndDate(),requestUpdate.getPeriod(),requestUpdate.getReason());
+        SleepoverApply requestUpdate = requestUpdateDto.toEntity(user);
+
+        if(updateSleepover.getApproved().equals(ApprovalType.Approved)) {
+            throw new CustomException(SLEEP_OVER_APPLY_TARGET_ERROR);
+        }else updateSleepover.updateSleepoverApply(requestUpdate.getStartDate(), requestUpdate.getEndDate(), requestUpdate.getPeriod(),requestUpdate.getAddress(), requestUpdate.getReason());
 
     }
 
@@ -75,7 +79,8 @@ public class SleepoverApplyService {
 
     @Transactional(readOnly = true)
     public SleepoverApplyDto.ResponseGetSleepoverApply getDetailSleepoverApply(Long sleepoverApplyId){
-       SleepoverApply getSleepoverApply = sleepoverApplyRepository.findById(sleepoverApplyId).get();
+       SleepoverApply getSleepoverApply = sleepoverApplyRepository.findById(sleepoverApplyId)
+               .orElseThrow(()-> new CustomException(SLEEP_OVER_APPLY_NOT_FOUND));
         return new SleepoverApplyDto.ResponseGetSleepoverApply(getSleepoverApply);
     }
 

--- a/src/main/java/com/duktown/domain/sleepoverApply/service/SleepoverApplyService.java
+++ b/src/main/java/com/duktown/domain/sleepoverApply/service/SleepoverApplyService.java
@@ -39,10 +39,8 @@ public class SleepoverApplyService {
         }
 
     }
-
-    //TODO: 외박 신청 수정 -> 하루 추가-> 추가 신청-> 이전 내역과 병합
-
-    // 외박 신청 수정 ->  하루 감소 => 기존 신청 이력을 수정
+    
+    // 외박 신청 수정 -> 승인 전-> 하루 감소, 하루 추가 => 기존 신청 이력을 수정
     public void updateSleepoverApply(Long userId,Long sleepoverApplyId ,SleepoverApplyDto.RequestSleepoverApplyDto requestUpdateDto){
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new CustomException(USER_NOT_FOUND));

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -58,7 +58,8 @@ public enum CustomErrorType {
 
     // SleepoverApply(9XXXX)
     SLEEP_OVER_APPLY_NOT_FOUND(NOT_FOUND,90001,"존재하지 않는 외박신청입니다."),
-    SLEEP_OVER_APPLY_INVALID_REQUEST_TIME(BAD_REQUEST,90002,"22시 이후에는 외박 신청이 불가능합니다.");
+    SLEEP_OVER_APPLY_INVALID_REQUEST_TIME(BAD_REQUEST,90002,"22시 이후에는 외박 신청이 불가능합니다."),
+    SLEEP_OVER_APPLY_TARGET_ERROR(BAD_REQUEST,90003,"승인 이후에는 수정 불가능합니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -57,7 +57,8 @@ public enum CustomErrorType {
     LIKE_TARGET_ERROR(BAD_REQUEST, 80002, "좋아요할 대상은 하나만 선택할 수 있습니다."),
 
     // SleepoverApply(9XXXX)
-    SLEEP_OVER_APPLY_NOT_FOUND(NOT_FOUND,90001,"존재하지 않는 외박신청입니다.");
+    SLEEP_OVER_APPLY_NOT_FOUND(NOT_FOUND,90001,"존재하지 않는 외박신청입니다."),
+    SLEEP_OVER_APPLY_INVALID_REQUEST_TIME(BAD_REQUEST,90002,"22시 이후에는 외박 신청이 불가능합니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/duktown/global/type/ApprovalType.java
+++ b/src/main/java/com/duktown/global/type/ApprovalType.java
@@ -1,4 +1,4 @@
-package com.duktown.domain.sleepoverApply.entity;
+package com.duktown.global.type;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 📝 PR 내용
1. 외박 신청 등록 기능 구현
도로명 주소 입력은 다음API를 기준으로 제작하였습니다. 도로명주소 대신 학교/과방 같은 입력 값은 streetAddress로 단일값으로 받고 있습니다.
2. 관리자 승인, 목록 조회, 상세 조회 구현
3. 학생 외박 신청 취소는 피그마 화면상에는 존재하지 않지만 차후 화면에 따라 기능 삭제 가능성 있습니다. 
4.학생  외박 신청 수정은 승인 후 날짜 연장인 경우 추가 신청으로 처리하고 승인 전 날짜 변경은 수정으로 처리합니다.

## 관련 이슈
close #28
