### PR TITLE
[FIX #41] SockJs 지원 해제, Websocket 연결은 jwt 토큰 인증 안하도록 수정

### DIFF
--- a/src/main/java/com/duktown/global/config/SecurityConfig.java
+++ b/src/main/java/com/duktown/global/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
             "/auth/email/**",
             "/auth/id/**",
             "/auth/password/**",
-            "/auth/signup"
+            "/auth/signup",
+            "/websocket"
     };
 
     @Value("${custom.cors.originUrl}")

--- a/src/main/java/com/duktown/global/config/StompConfig.java
+++ b/src/main/java/com/duktown/global/config/StompConfig.java
@@ -21,9 +21,9 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/websocket")
                 .setAllowedOrigins("*");
-        registry.addEndpoint("/sockjs")
-                .setAllowedOrigins("*")
-                .withSockJS();
+//        registry.addEndpoint("/sockjs")
+//                .setAllowedOrigins("*")
+//                .withSockJS();
         registry.setErrorHandler(chatErrorHandler);
     }
 


### PR DESCRIPTION
## 📝 PR 내용
SockJs 지원 해제, Websocket 연결은 jwt 토큰 인증 안하도록 수정

## 관련 이슈
#41 (already closed)
