### PR TITLE
[FIX #41] 나가기한 채팅방도 참여중인 채팅방 목록으로 조회되는 문제 해결

### DIFF
--- a/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
@@ -146,6 +146,11 @@ public class ChatRoomService {
         List<ChatRoomDto.ChatRoomListElementResponse> chatRooms = new ArrayList<>();
 
         for (ChatRoomUser chatRoomUser : chatRoomUsers) {
+            // 나간 채팅방은 조회 x
+            if (chatRoomUser.getChatRoomUserType() == ChatRoomUserType.DELETED) {
+                continue;
+            }
+
             // 참여중인 채팅방 찾기
             ChatRoom chatRoom = chatRoomUser.getChatRoom();
 


### PR DESCRIPTION
## 📝 PR 내용
나가기한 채팅방은 참여중인 채팅방 목록으로 조회되지 않도록 수정

## 관련 이슈
close #41 
