### PR TITLE
Feature/#63 마이페이지 기능 구현 및 채팅관련 오류 수정

### DIFF
--- a/src/main/java/com/duktown/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/duktown/domain/chat/dto/ChatDto.java
@@ -62,8 +62,8 @@ public class ChatDto {
 
             return MessageResponse.builder()
                     .chatId(chat.getId())
-                    .userId(chat.getUser().getId())
-                    .userNumber(chatRoomUser.getUserNumber())
+                    .userId(!chat.getUser().isDeleted() ? chat.getUser().getId() : null)
+                    .userNumber(!chat.getUser().isDeleted() ? chatRoomUser.getUserNumber() : null)
                     .chatType(chat.getChatType())
                     .message(chat.getContent())
                     .createdAt(chat.getCreatedAt().toString())

--- a/src/main/java/com/duktown/domain/chatRoom/dto/ChatRoomDto.java
+++ b/src/main/java/com/duktown/domain/chatRoom/dto/ChatRoomDto.java
@@ -28,7 +28,7 @@ public class ChatRoomDto {
         private String orderTime;
         private String accountNumber;
 
-        public static ChatRoomResponse from(ChatRoomUser chatRoomUser, Delivery delivery, String accountNumber) {
+        public static ChatRoomResponse from(ChatRoomUser chatRoomUser, Delivery delivery, String accountNumber, Integer chatRoomUserCnt) {
             return ChatRoomResponse.builder()
                     .getRequestUserId(chatRoomUser.getUser().getId())
                     .getRequestUserNumber(chatRoomUser.getUserNumber())
@@ -37,7 +37,7 @@ public class ChatRoomDto {
                     .deliveryDeleted(delivery.getDeleted())
                     .title(delivery.getTitle())
                     .maxPeople(delivery.getMaxPeople())
-                    .chatRoomUserCnt(delivery.getChatRoom().getChatRoomUsers().size())
+                    .chatRoomUserCnt(chatRoomUserCnt)
                     .orderTime(DateUtil.convertToAMPMFormat(delivery.getOrderTime()))
                     .accountNumber(accountNumber)
                     .build();

--- a/src/main/java/com/duktown/domain/chatRoom/entity/ChatRoomRepository.java
+++ b/src/main/java/com/duktown/domain/chatRoom/entity/ChatRoomRepository.java
@@ -3,7 +3,6 @@ package com.duktown.domain.chatRoom.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/duktown/domain/chatRoom/entity/ChatRoomRepository.java
+++ b/src/main/java/com/duktown/domain/chatRoom/entity/ChatRoomRepository.java
@@ -3,6 +3,7 @@ package com.duktown.domain.chatRoom.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
@@ -96,7 +96,12 @@ public class ChatRoomService {
 
         // 초대된 적 없다면 chatRoomUser 등록
         else {
-            chatRoomUser = chatRoomUserRepository.save(request.toEntity(inviteUser, chatRoom));
+            // 기존에 같은 유저넘버로 저장된 사용자가 있으면 등록 불가
+            if (!chatRoomUserRepository.existsByChatRoomIdAndUserNumber(chatRoom.getId(), request.getUserNumber())) {
+                chatRoomUser = chatRoomUserRepository.save(request.toEntity(inviteUser, chatRoom));
+            } else {
+                throw new CustomException(ALREADY_SAME_NUMBER_CHAT_ROOM_USER_EXISTS);
+            }
         }
 
         String message = "익명" + chatRoomUser.getUserNumber() + "님이 들어왔습니다.";

--- a/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
@@ -135,8 +135,9 @@ public class ChatRoomService {
 
         Delivery delivery = deliveryRepository.findByChatRoomId(chatRoomId).orElseThrow(() -> new CustomException(DELIVERY_NOT_FOUND));
         ChatRoomUser chatRoomUser = chatRoomUserRepository.findByChatRoomIdAndUserId(chatRoomId, userId).orElseThrow(() -> new CustomException(CHAT_ROOM_USER_NOT_FOUND));
+        Integer chatRoomUserCnt = chatRoomUserRepository.countByChatRoomId(chatRoomId, ChatRoomUserType.ACTIVE);
 
-        return ChatRoomDto.ChatRoomResponse.from(chatRoomUser, delivery, seed.decrypt(delivery.getAccountNumber()));
+        return ChatRoomDto.ChatRoomResponse.from(chatRoomUser, delivery, seed.decrypt(delivery.getAccountNumber()), chatRoomUserCnt);
     }
 
     // 내가 참여중인 채팅방 목록 조회 TODO : 페이징 처리, 안 읽은 개수 표시

--- a/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/duktown/domain/chatRoom/service/ChatRoomService.java
@@ -9,6 +9,7 @@ import com.duktown.domain.chatRoom.entity.ChatRoomRepository;
 import com.duktown.domain.chatRoomUser.dto.ChatRoomUserDto;
 import com.duktown.domain.chatRoomUser.entity.ChatRoomUser;
 import com.duktown.domain.chatRoomUser.entity.ChatRoomUserRepository;
+import com.duktown.domain.comment.entity.CommentRepository;
 import com.duktown.domain.delivery.entity.Delivery;
 import com.duktown.domain.delivery.entity.DeliveryRepository;
 import com.duktown.domain.user.entity.User;
@@ -42,6 +43,7 @@ public class ChatRoomService {
     private final SEED seed;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChatRepository chatRepository;
+    private final CommentRepository commentRepository;
 
     // 배달팟 채팅방 초대하기
     @Transactional
@@ -52,6 +54,10 @@ public class ChatRoomService {
         // 자기 자신은 초대 불가
         if (user.getId().equals(request.getInviteUserId())) {
             throw new CustomException(CANNOT_INVITE_SELF);
+        }
+
+        if (commentRepository.findAllByDeliveryIdAndUserId(request.getDeliveryId(), request.getInviteUserId()).isEmpty()) {
+            throw new CustomException(DELIVERY_COMMENT_NOT_FOUND);
         }
 
         Delivery delivery = deliveryRepository.findById(request.getDeliveryId()).orElseThrow(() -> new CustomException(DELIVERY_NOT_FOUND));

--- a/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUser.java
+++ b/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUser.java
@@ -41,4 +41,8 @@ public class ChatRoomUser extends BaseTimeEntity {
     public void changeChatRoomUserType(ChatRoomUserType chatRoomUserType) {
         this.chatRoomUserType = chatRoomUserType;
     }
+
+    public void deleteUser() {
+        userNumber = null;
+    }
 }

--- a/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUser.java
+++ b/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUser.java
@@ -41,8 +41,4 @@ public class ChatRoomUser extends BaseTimeEntity {
     public void changeChatRoomUserType(ChatRoomUserType chatRoomUserType) {
         this.chatRoomUserType = chatRoomUserType;
     }
-
-    public void deleteUser() {
-        userNumber = null;
-    }
 }

--- a/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUserRepository.java
+++ b/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUserRepository.java
@@ -1,6 +1,9 @@
 package com.duktown.domain.chatRoomUser.entity;
 
+import com.duktown.global.type.ChatRoomUserType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,11 +12,12 @@ import java.util.Optional;
 @Repository
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
 
-    Integer countByChatRoomId(Long chatRoomId);
-
     Boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 
     Optional<ChatRoomUser> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 
     List<ChatRoomUser> findAllByUserId(Long userId);
+
+    @Query("select count(cru) from ChatRoomUser cru where cru.chatRoom.id = :chatRoomId and cru.chatRoomUserType = :chatRoomUserType")
+    Integer countByChatRoomId(@Param("chatRoomId") Long chatRoomId, @Param("chatRoomUserType")ChatRoomUserType chatRoomUserType);
 }

--- a/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUserRepository.java
+++ b/src/main/java/com/duktown/domain/chatRoomUser/entity/ChatRoomUserRepository.java
@@ -14,6 +14,8 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
 
     Boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 
+    Boolean existsByChatRoomIdAndUserNumber(Long chatRoomId, Integer userNumber);
+
     Optional<ChatRoomUser> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 
     List<ChatRoomUser> findAllByUserId(Long userId);

--- a/src/main/java/com/duktown/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/duktown/domain/comment/dto/CommentDto.java
@@ -79,8 +79,8 @@ public class CommentDto {
                     .collect(Collectors.toList());
             return ParentResponse.builder()
                     .commentId(comment.getId())
-                    .userId(comment.getUser().getId())
-                    .userTitle(comment.getUserTitle())
+                    .userId(!comment.getUser().isDeleted() ? comment.getUser().getId() : null)
+                    .userTitle(!comment.getUser().isDeleted() ? comment.getUserTitle() : "(알수없음)")
                     .content(comment.getContent())
                     .liked(likes.stream().anyMatch(l -> l.getComment().getId().equals(comment.getId())))
                     .likeCount(comment.getLikes().size())
@@ -108,8 +108,8 @@ public class CommentDto {
         public static ChildResponse from(Comment comment, List<Like> likes, Boolean isWriter) {
             return ChildResponse.builder()
                     .commentId(comment.getId())
-                    .userId(comment.getUser().getId())
-                    .userTitle(comment.getUserTitle())
+                    .userId(!comment.getUser().isDeleted() ? comment.getUser().getId() : null)
+                    .userTitle(!comment.getUser().isDeleted() ? comment.getUserTitle() : "(알수없음)")
                     .content(comment.getContent())
                     .liked(likes.stream().anyMatch(l -> l.getComment().getId().equals(comment.getId())))
                     .likeCount(comment.getLikes().size())

--- a/src/main/java/com/duktown/domain/comment/entity/CommentRepository.java
+++ b/src/main/java/com/duktown/domain/comment/entity/CommentRepository.java
@@ -19,6 +19,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByDeliveryId(Long deliveryId);
 
+    List<Comment> findAllByDeliveryIdAndUserId(Long deliveryId, Long userId);
+
     List<Comment> findAllByPostId(Long postId);
 
     Boolean existsByParentCommentId(Long parentCommentId);

--- a/src/main/java/com/duktown/domain/delivery/dto/DeliveryDto.java
+++ b/src/main/java/com/duktown/domain/delivery/dto/DeliveryDto.java
@@ -75,7 +75,7 @@ public class DeliveryDto {
         private Boolean isWriter;
 
 
-        public static DeliveryResponse from(Delivery delivery, Boolean isWriter) {
+        public static DeliveryResponse from(Delivery delivery, Boolean isWriter, Integer peopleCount) {
             return DeliveryResponse.builder()
                     .userId(delivery.getUser().getId())
                     .deliveryId(delivery.getId())
@@ -84,7 +84,7 @@ public class DeliveryDto {
                     .maxPeople(delivery.getMaxPeople())
                     .orderTime(DateUtil.convertToAMPMFormat(delivery.getOrderTime()))
                     .content(delivery.getContent())
-                    .peopleCount(delivery.getChatRoom().getChatRoomUsers().size())
+                    .peopleCount(peopleCount)
                     .commentCount(delivery.getComments().size())
                     .active(delivery.getActive())
                     .isWriter(isWriter)

--- a/src/main/java/com/duktown/domain/delivery/entity/DeliveryRepository.java
+++ b/src/main/java/com/duktown/domain/delivery/entity/DeliveryRepository.java
@@ -11,24 +11,25 @@ import java.util.Optional;
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
-    @Query(value = "select d from Delivery d where d.id = :deliveryId and d.deleted = false ")
+    @Query(value = "select d from Delivery d where d.id = :deliveryId and d.deleted = false and d.user.deleted = false")
     Optional<Delivery> findById(@Param("deliveryId") Long deliveryId);
 
-    Optional<Delivery> findByChatRoomId(Long chatRoomId);
+    @Query(value = "select d from Delivery d where d.chatRoom.id = :chatRoomId and d.user.deleted = false")
+    Optional<Delivery> findByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
-    @Query(value = "select d from Delivery d where d.deleted = false order by d.createdAt desc")
+    @Query(value = "select d from Delivery d where d.deleted = false and d.user.deleted = false order by d.createdAt desc")
     List<Delivery> findAllSortByCreatedAt();
 
-    @Query(value = "select d from Delivery d where d.deleted = false order by d.orderTime")
+    @Query(value = "select d from Delivery d where d.deleted = false and d.user.deleted = false order by d.orderTime")
     List<Delivery> findAllSortByOrderTime();
 
-    @Query(value = "select d from Delivery d where d.user.id = :user_id and d.deleted = false order by d.createdAt desc")
+    @Query(value = "select d from Delivery d where d.user.id = :user_id and d.deleted = false and d.user.deleted = false order by d.createdAt desc")
     List<Delivery> findAllByUserIdSortByCreatedAt(@Param("user_id") Long userId);
 
-    @Query(value = "select d from Delivery d where d.user.id = :user_id and d.deleted = false order by d.orderTime")
+    @Query(value = "select d from Delivery d where d.user.id = :user_id and d.deleted = false and d.user.deleted = false order by d.orderTime")
     List<Delivery> findAllByUserIdSortByOrderTime(@Param("user_id") Long userId);
 
-    @Query("SELECT d FROM Delivery d WHERE LOWER(d.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(d.content) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY d.orderTime DESC")
+    @Query("SELECT d FROM Delivery d WHERE d.user.deleted = false AND LOWER(d.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(d.content) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY d.orderTime DESC")
     List<Delivery> searchByKeywordOrdered(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/duktown/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/duktown/domain/delivery/service/DeliveryService.java
@@ -158,7 +158,8 @@ public class DeliveryService {
 
         List<DeliveryDto.DeliveryResponse> content = deliveries
                 .stream()
-                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId)))
+                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId),
+                        chatRoomUserRepository.countByChatRoomId(d.getChatRoom().getId(), ChatRoomUserType.ACTIVE)))
                 .collect(Collectors.toList());
 
         return new DeliveryDto.DeliveryListResponse(content);
@@ -171,8 +172,9 @@ public class DeliveryService {
 
         // 글쓴이인지 여부
         Boolean isWriter = delivery.getUser().getId().equals(userId);
+        Integer peopleCnt = chatRoomUserRepository.countByChatRoomId(delivery.getChatRoom().getId(), ChatRoomUserType.ACTIVE);
 
-        return DeliveryDto.DeliveryResponse.from(delivery, isWriter);
+        return DeliveryDto.DeliveryResponse.from(delivery, isWriter, peopleCnt);
     }
 
     // 삭제
@@ -198,16 +200,16 @@ public class DeliveryService {
 
     // 검색
     public DeliveryDto.DeliveryListResponse searchDeliveryList(Long userId, String keyword) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         List<Delivery> deliveries = deliveryRepository.searchByKeywordOrdered(keyword);
 
         List<DeliveryDto.DeliveryResponse> content = deliveries
                 .stream()
-                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId)))
+                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId),
+                        chatRoomUserRepository.countByChatRoomId(d.getChatRoom().getId(), ChatRoomUserType.ACTIVE)))
                 .collect(Collectors.toList());
 
         return new DeliveryDto.DeliveryListResponse(content);
-
     }
 }

--- a/src/main/java/com/duktown/domain/post/entity/Post.java
+++ b/src/main/java/com/duktown/domain/post/entity/Post.java
@@ -9,7 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -51,12 +50,11 @@ public class Post extends BaseTimeEntity {
     @OneToMany(fetch = LAZY, mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
-//
 //    @OneToMany(fetch = LAZY, mappedBy = "post")
 //    private List<Like> likes
     @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private List<Like> likes = new ArrayList<>();;
+    private List<Like> likes = new ArrayList<>();
 
 
     public void update(String title, String content){

--- a/src/main/java/com/duktown/domain/post/entity/Post.java
+++ b/src/main/java/com/duktown/domain/post/entity/Post.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/duktown/domain/post/entity/PostRepository.java
+++ b/src/main/java/com/duktown/domain/post/entity/PostRepository.java
@@ -9,20 +9,24 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post,Long> {
-    // 목록 조회 - 페이지네이션, 카테고리
 
-    @Query("select p from Post p where p.category = :category order by p.createdAt desc")
+    @Query("select p from Post p where p.id = :post_id and p.user.deleted = false")
+    Optional<Post> findById(@Param("post_id") Long postId);
+
+    // 목록 조회 - 페이지네이션, 카테고리
+    @Query("select p from Post p where p.category = :category and p.user.deleted = false order by p.createdAt desc")
     Slice<Post> findAllByCategory(@Param(value = "category") Category category,Pageable pageable);
 
     // 일상 0, 장터 1 검색
-    @Query("SELECT p FROM Post p WHERE p.category = :category AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%) ")
+    @Query("SELECT p FROM Post p WHERE p.category = :category and p.user.deleted = false AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%) ")
     Slice<Post> findByCategoryAndKeyword( @Param("category") Category category, @Param("keyword") String keyword,Pageable pageable);
 
 
-    @Query("select p from Post p where p.user.id = :user_id and p.category = :category order by p.createdAt desc")
+    @Query("select p from Post p where p.user.id = :user_id and p.category = :category and p.user.deleted = false order by p.createdAt desc")
     List<Post> findAllByUserAndCategory(@Param("user_id") Long userId, @Param(value = "category") Category category);
 
 

--- a/src/main/java/com/duktown/domain/post/service/Post1PageCache.java
+++ b/src/main/java/com/duktown/domain/post/service/Post1PageCache.java
@@ -19,13 +19,16 @@ public class Post1PageCache {
     private Slice<Post> page1;
     private final PostRepository postRepository;
 
-    @Scheduled(cron ="30 * * * * *" )
+    @Scheduled(cron ="30 * * * * *")
     @Transactional(readOnly = true)
     public void updateCache(){
-        Pageable pageable = PageRequest.of(0, 5, Sort.by(Sort.Order.desc("createdAt")));
-        page1 = postRepository.findAllByCategory(Category.DAILY,pageable);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.desc("createdAt")));
+        page1 = postRepository.findAllByCategory(Category.DAILY, pageable);
     }
+
+    @Transactional(readOnly = true)
     public Slice<Post> getPage1(){
+        updateCache();
         return page1;
     }
 }

--- a/src/main/java/com/duktown/domain/post/service/PostService.java
+++ b/src/main/java/com/duktown/domain/post/service/PostService.java
@@ -73,7 +73,7 @@ public class PostService {
         if(pageNo == 1 && findCategory.equals(Category.DAILY)){
             posts = post1PageCache.getPage1();
         }else {
-            Pageable pageable = PageRequest.of(pageNo - 1, 5, Sort.by(Sort.Order.desc("createdAt")));
+            Pageable pageable = PageRequest.of(pageNo - 1, 10, Sort.by(Sort.Order.desc("createdAt")));
             posts = postRepository.findAllByCategory(findCategory,pageable);
         }
 

--- a/src/main/java/com/duktown/domain/post/service/PostService.java
+++ b/src/main/java/com/duktown/domain/post/service/PostService.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/duktown/domain/profile/dto/ProfileDto.java
+++ b/src/main/java/com/duktown/domain/profile/dto/ProfileDto.java
@@ -1,7 +1,9 @@
 package com.duktown.domain.profile.dto;
 
+import com.duktown.domain.unit.entity.Unit;
 import com.duktown.domain.unitUser.entity.UnitUser;
 import com.duktown.domain.user.entity.User;
+import com.duktown.global.type.HallName;
 import com.duktown.global.type.RoleType;
 import com.duktown.global.type.UnitUserType;
 import lombok.AllArgsConstructor;
@@ -20,19 +22,21 @@ public class ProfileDto {
     public static class ProfileResponse {
         private String name;
         private String email;
-//        private HallName hallName;
-//        private Integer buildingNumber;
-//        private Integer roomNumber;
+        private HallName hallName;
+        private Integer buildingNumber;
+        private Integer roomNumber;
+        private UnitUserType unitUserType;
         private RoleType roleType;
 
         //TODO: 유닛정보 추가
-        public static ProfileResponse from(User user) { //, Unit unit
+        public static ProfileResponse from(User user, Unit unit, UnitUserType unitUserType) {
             return ProfileResponse.builder()
                     .name(user.getName())
                     .email(user.getEmail())
-//                    .hallName(unit.getHallName())
-//                    .buildingNumber(unit.getBuildingNumber())
-//                    .roomNumber(unit.getRoomNumber())
+                    .hallName(unit.getHallName())
+                    .buildingNumber(unit.getBuildingNumber())
+                    .roomNumber(unit.getRoomNumber())
+                    .unitUserType(unitUserType)
                     .roleType(user.getRoleType())
                     .build();
         }

--- a/src/main/java/com/duktown/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/duktown/domain/profile/service/ProfileService.java
@@ -1,5 +1,6 @@
 package com.duktown.domain.profile.service;
 
+import com.duktown.domain.chatRoomUser.entity.ChatRoomUserRepository;
 import com.duktown.domain.comment.entity.Comment;
 import com.duktown.domain.comment.entity.CommentRepository;
 import com.duktown.domain.delivery.dto.DeliveryDto;
@@ -11,10 +12,13 @@ import com.duktown.domain.post.dto.PostDto;
 import com.duktown.domain.post.entity.Post;
 import com.duktown.domain.post.entity.PostRepository;
 import com.duktown.domain.profile.dto.ProfileDto;
+import com.duktown.domain.unitUser.entity.UnitUser;
+import com.duktown.domain.unitUser.entity.UnitUserRepository;
 import com.duktown.domain.user.entity.User;
 import com.duktown.domain.user.entity.UserRepository;
 import com.duktown.global.exception.CustomException;
 import com.duktown.global.type.Category;
+import com.duktown.global.type.ChatRoomUserType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,12 +38,14 @@ public class ProfileService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+    private final UnitUserRepository unitUserRepository;
 
     public ProfileDto.ProfileResponse getMyProfile(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UnitUser unitUser = unitUserRepository.findByUserId(userId).orElseThrow(() -> new CustomException(UNIT_USER_NOT_FOUND));
 
-        // TODO: 유닛 정보 추가
-        return ProfileDto.ProfileResponse.from(user);
+        return ProfileDto.ProfileResponse.from(user, unitUser.getUnit(), unitUser.getUnitUserType());
     }
 
     // 내가 작성한 배달팟 조회
@@ -59,7 +65,8 @@ public class ProfileService {
 
         List<DeliveryDto.DeliveryResponse> content = deliveries
                 .stream()
-                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId)))
+                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId),
+                        chatRoomUserRepository.countByChatRoomId(d.getChatRoom().getId(), ChatRoomUserType.ACTIVE)))
                 .collect(Collectors.toList());
 
         return new DeliveryDto.DeliveryListResponse(content);
@@ -83,7 +90,8 @@ public class ProfileService {
 
         List<DeliveryDto.DeliveryResponse> content = deliveries
                 .stream()
-                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId)))
+                .map(d -> DeliveryDto.DeliveryResponse.from(d, d.getUser().getId().equals(userId),
+                        chatRoomUserRepository.countByChatRoomId(d.getChatRoom().getId(), ChatRoomUserType.ACTIVE)))
                 .collect(Collectors.toList());
 
         return new DeliveryDto.DeliveryListResponse(content);

--- a/src/main/java/com/duktown/domain/user/controller/UserController.java
+++ b/src/main/java/com/duktown/domain/user/controller/UserController.java
@@ -71,4 +71,12 @@ public class UserController {
         userService.temporaryPwdEmailSend(request);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/withdrawal")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        userService.withdraw(customUserDetails.getId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/duktown/domain/user/entity/User.java
+++ b/src/main/java/com/duktown/domain/user/entity/User.java
@@ -1,17 +1,12 @@
 package com.duktown.domain.user.entity;
 
 import com.duktown.domain.BaseTimeEntity;
-import com.duktown.domain.unit.entity.Unit;
-import com.duktown.global.exception.CustomErrorType;
-import com.duktown.global.exception.CustomException;
 import com.duktown.global.type.RoleType;
-import com.duktown.global.type.UnitUserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/duktown/domain/user/entity/User.java
+++ b/src/main/java/com/duktown/domain/user/entity/User.java
@@ -10,8 +10,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
+
+import java.time.LocalDateTime;
 
 import static javax.persistence.EnumType.*;
 import static javax.persistence.GenerationType.*;
@@ -23,34 +27,40 @@ import static lombok.AccessLevel.*;
 @AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "users")
+@SQLDelete(sql = "UPDATE users SET deleted = true, deleted_at = CURRENT_TIMESTAMP, " +
+        "name = '(탈퇴한 회원)', email = null, login_id = null, " +
+        "password = null, refresh_token = null, role_type = null, available_period = null " +
+        "WHERE user_id = ?")
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "user_id")
     private Long id;
 
-    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
     private String loginId;
 
-    @Column(nullable = false)
     private String password;
 
     @Builder.Default
     @Enumerated(value = STRING)
-    @Column(nullable = false)
     private RoleType roleType = RoleType.DORM_STUDENT;
 
     private String refreshToken;
 
     //TODO: 외박 일 수 관련해서 질문하기
     // 남은 외박 일 수
-    private Integer availablePeriod;
+    @Builder.Default
+    private Integer availablePeriod = 16;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
@@ -64,17 +74,8 @@ public class User extends BaseTimeEntity {
         this.password = encodedPwd;
     }
 
-    @PrePersist
-    private void baseAvailablePeriod(){
-        // 외박 가능 일수 초기값 부여
-        availablePeriod = 16;
-    }
-
     public void downAvailablePeriod(Integer period){
         // 외박 가능 일수 다운
-            this.availablePeriod -= period;
+        this.availablePeriod -= period;
     }
-
-
-
 }

--- a/src/main/java/com/duktown/domain/user/entity/UserRepository.java
+++ b/src/main/java/com/duktown/domain/user/entity/UserRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/duktown/domain/user/entity/UserRepository.java
+++ b/src/main/java/com/duktown/domain/user/entity/UserRepository.java
@@ -1,6 +1,8 @@
 package com.duktown.domain.user.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -8,13 +10,16 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByIdAndLoginId(Long id, String loginId);
 
-    Optional<User> findByEmail(String email);
+    @Query("select u from User u where u.deleted = false and u.id = :id and u.loginId = :loginId")
+    Optional<User> findByIdAndLoginId(@Param("id") Long id, @Param("loginId") String loginId);
 
-    Optional<User> findByLoginId(String loginId);
+    @Query("select u from User u where u.deleted = false and u.email = :email")
+    Optional<User> findByEmail(@Param("email") String email);
 
-    Optional<User> findById(Long id);
+    @Query("select u from User u where u.deleted = false and u.loginId = :loginId")
+    Optional<User> findByLoginId(@Param("loginId") String loginId);
 
-
+    @Query("select u from User u where u.deleted = false and u.id = :id")
+    Optional<User> findById(@Param("id") Long id);
 }

--- a/src/main/java/com/duktown/domain/user/service/UserService.java
+++ b/src/main/java/com/duktown/domain/user/service/UserService.java
@@ -167,7 +167,6 @@ public class UserService {
         List<ChatRoomUser> chatRoomUsers = chatRoomUserRepository.findAllByUserId(userId);
         for (ChatRoomUser chatRoomUser : chatRoomUsers) {
             chatRoomUser.changeChatRoomUserType(ChatRoomUserType.DELETED);
-            chatRoomUser.deleteUser();
 
             String message;
             ChatType chatType;

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -78,6 +78,7 @@ public enum CustomErrorType {
     BLOCKED_CHAT_ROOM_USER(BAD_REQUEST, 100009, "해당 채팅방에서 차단된 사용자입니다."),
     BLOCKED_FROM_CHAT_ROOM(BAD_REQUEST, 100010, "이용이 제한되어 더이상 참여할 수 없는 채팅방입니다."),
     DELETED_CHAT_ROOM_USER(BAD_REQUEST, 100011, "채팅방에서 나가기한 사용자입니다."),
+    ALREADY_SAME_NUMBER_CHAT_ROOM_USER_EXISTS(BAD_REQUEST, 100012, "이미 같은 익명 숫자로 초대된 사용자가 존재합니다."),
 
     // Unit(11xxxx)
     UNIT_NOT_FOUND(NOT_FOUND, 110001, "존재하지 않는 유닛입니다."),

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -50,7 +50,7 @@ public enum CustomErrorType {
     // Comment(7xxxx)
     COMMENT_NOT_FOUND(NOT_FOUND, 70001, "존재하지 않는 댓글입니다."),
     PARENT_COMMENT_NOT_FOUND(NOT_FOUND, 70002, "존재하지 않는 상위 댓글입니다."),
-    DELIVERY_COMMENT_NOT_FOUND(NOT_FOUND, 40004, "배달팟에 댓글 단 내역이 존재하지 않습니다."),
+    DELIVERY_COMMENT_NOT_FOUND(NOT_FOUND, 70003, "배달팟에 댓글 단 내역이 존재하지 않습니다."),
 
     COMMENT_TARGET_NOT_SELECTED(BAD_REQUEST, 70003, "댓글을 생성하거나 조회할 대상이 선택되지 않았습니다."),
     COMMENT_DEPTH_ERROR(BAD_REQUEST, 70004, "대댓글에 대댓글을 달 수 없습니다."),

--- a/src/main/java/com/duktown/global/exception/CustomErrorType.java
+++ b/src/main/java/com/duktown/global/exception/CustomErrorType.java
@@ -50,6 +50,7 @@ public enum CustomErrorType {
     // Comment(7xxxx)
     COMMENT_NOT_FOUND(NOT_FOUND, 70001, "존재하지 않는 댓글입니다."),
     PARENT_COMMENT_NOT_FOUND(NOT_FOUND, 70002, "존재하지 않는 상위 댓글입니다."),
+    DELIVERY_COMMENT_NOT_FOUND(NOT_FOUND, 40004, "배달팟에 댓글 단 내역이 존재하지 않습니다."),
 
     COMMENT_TARGET_NOT_SELECTED(BAD_REQUEST, 70003, "댓글을 생성하거나 조회할 대상이 선택되지 않았습니다."),
     COMMENT_DEPTH_ERROR(BAD_REQUEST, 70004, "대댓글에 대댓글을 달 수 없습니다."),


### PR DESCRIPTION
## 📝 PR 내용
- 마이페이지 
  - 회원 프로필 조회 시 유닛 정보 및 유닛 역할 조회
  - 나의 유닛 조회
  - 회원 탈퇴 기능 구현
 
- 회원탈퇴
  - 게시글 -> 탈퇴한 회원 게시글은 조회되지 않음
  - 댓글 -> 탈퇴한 회원의 경우 '알수없음'으로 표시됨(userId = null로 반환)
  - 배달팟 -> 탈퇴한 회원 게시글은 조회되지 않음
  - 채팅방 -> 탈퇴 시 채팅방 나가기 처리됨 "(알수없음)님이 나갔습니다."
  - 채팅 -> 탈퇴 후 채팅 조회 시 채팅 보낸 사람 정보 userNumber = 알수없음, userId = null

- 채팅방 나가기 시 배달팟, 채팅방 참여 인원이 줄어들지 않던 문제 해결
- 채팅방 나가기 또는 내보내기된 유저는 채팅 전송 불가, 채팅방 주인이 나가기했을 때 채팅 전송 불가 수정
- 기존에 같은 유저넘버로 저장된 채팅방 참여자가 있으면 등록이 불가하도록 수정
- 배달팟에 댓글 단 내역 없을 시 채팅방 초대 불가 구현

## 관련 이슈
close #63 